### PR TITLE
Fix sending the nodes to the custom presentation

### DIFF
--- a/kolibri_explore_plugin/assets/src/views/CustomChannelPresentationApp.vue
+++ b/kolibri_explore_plugin/assets/src/views/CustomChannelPresentationApp.vue
@@ -72,7 +72,7 @@
             const message = {
               event,
               nameSpace,
-              data: { channel, node },
+              data: { channel, nodes: node },
             };
             iframeWindow.postMessage(message, '*');
           });


### PR DESCRIPTION
This was introduced in bc81da5e for linting, and accidentally changed the name.

https://phabricator.endlessm.com/T31232