### PR TITLE
Add custom Base component

### DIFF
--- a/kolibri_explore_plugin/assets/src/views/Base.vue
+++ b/kolibri_explore_plugin/assets/src/views/Base.vue
@@ -1,0 +1,98 @@
+<template>
+
+  <div
+    ref="mainWrapper"
+    class="main-wrapper"
+  >
+    <SideNav
+      :navShown="navShown"
+      :headerHeight="headerHeight"
+      :width="navWidth"
+      @toggleSideNav="navShown = !navShown"
+    />
+
+    <div v-if="!loading" class="explore-main-content">
+      <div class="explore-buttons">
+        <KIconButton
+          v-if="!back"
+          icon="menu"
+          size="large"
+          appearance="raised-button"
+          @click="navShown = !navShown"
+        />
+        <KIconButton
+          v-if="back"
+          class="right"
+          icon="close"
+          size="large"
+          appearance="raised-button"
+          @click="goBack()"
+        />
+      </div>
+      <slot></slot>
+    </div>
+  </div>
+
+</template>
+
+
+<script>
+
+  import { mapState } from 'vuex';
+  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import KIconButton from 'kolibri-design-system/lib/buttons-and-links/KIconButton';
+  import SideNav from 'kolibri.coreVue.components.SideNav';
+
+  export default {
+    name: 'Base',
+    components: {
+      SideNav,
+      KIconButton,
+    },
+    mixins: [responsiveWindowMixin],
+    props: {
+      back: {
+        type: Boolean,
+        default: false,
+      },
+    },
+    data() {
+      return {
+        navShown: false,
+      };
+    },
+    computed: {
+      headerHeight() {
+        return this.windowIsSmall ? 56 : 64;
+      },
+      navWidth() {
+        return this.headerHeight * 4;
+      },
+      ...mapState({
+        loading: state => state.core.loading,
+      }),
+    },
+    methods: {
+      goBack() {
+        if (window.history.length > 1) this.$router.go(-1);
+        else this.$router.push('/');
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .explore-main-content {
+    position: relative;
+  }
+
+  .explore-buttons {
+    position: absolute;
+    top: 10px;
+    left: 5px;
+  }
+
+</style>

--- a/kolibri_explore_plugin/assets/src/views/ChannelsPage.vue
+++ b/kolibri_explore_plugin/assets/src/views/ChannelsPage.vue
@@ -64,9 +64,7 @@
 
   .channels {
     width: 100%;
-
-    // Remove header size (64px) and 5px for avoiding scrollbar.
-    height: calc(100vh - 64px);
+    height: 100vh;
     min-height: 600px;
     padding: 20px;
     color: white;

--- a/kolibri_explore_plugin/assets/src/views/CustomChannelPresentationApp.vue
+++ b/kolibri_explore_plugin/assets/src/views/CustomChannelPresentationApp.vue
@@ -131,8 +131,8 @@
 
   .custom-presentation-iframe {
     width: 100%;
-    // Remove header size (64px) and 5px for avoiding scrollbar.
-    height: calc(100vh - 64px - 5px);
+    // Remove 5px for avoiding scrollbar.
+    height: 100vh;
     margin-bottom: -5px;
   }
 

--- a/kolibri_explore_plugin/assets/src/views/ExploreIndex.vue
+++ b/kolibri_explore_plugin/assets/src/views/ExploreIndex.vue
@@ -1,22 +1,6 @@
 <template>
 
-  <CoreBase
-    :marginBottom="bottomSpaceReserved"
-    :authorized="userIsAuthorized"
-    authorizedRole="registeredUser"
-    v-bind="immersivePageProps"
-    :maxMainWidth="Infinity"
-  >
-    <template v-if="pageName !== 'TOPICS_ROOT'" slot="app-bar-actions">
-      <router-link
-        class="rm-link-style"
-        :style="{ color: $themeTokens.textInverted }"
-        to="/"
-      >
-        Back
-      </router-link>
-    </template>
-
+  <BaseComponent :back="pageName !== 'TOPICS_ROOT'">
     <!--
       Topics pages have a different heading style which
       includes passing the breadcrumbs
@@ -30,20 +14,18 @@
       <component :is="currentPage" v-if="currentPage" />
       <router-view />
     </div>
-
-  </CoreBase>
+  </BaseComponent>
 
 </template>
 
 
 <script>
 
-  import { mapGetters, mapState } from 'vuex';
-  import lastItem from 'lodash/last';
+  import { mapState } from 'vuex';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
-  import CoreBase from 'kolibri.coreVue.components.CoreBase';
   import { PageNames } from '../constants';
+  import BaseComponent from './Base';
   import commonExploreStrings from './commonExploreStrings';
   import ChannelsPage from './ChannelsPage';
   import CustomChannelsPage from './CustomChannelsPage';
@@ -63,7 +45,7 @@
   export default {
     name: 'ExploreIndex',
     components: {
-      CoreBase,
+      BaseComponent,
     },
     mixins: [commonCoreStrings, commonExploreStrings, responsiveWindowMixin],
     data() {
@@ -72,15 +54,7 @@
       };
     },
     computed: {
-      ...mapGetters(['isUserLoggedIn']),
-      ...mapState('topicsTree', {
-        topicsTreeContent: 'content',
-        topicsTreeChannel: 'channel',
-      }),
       ...mapState(['pageName']),
-      userIsAuthorized() {
-        return this.$store.getters.allowAccess || this.isUserLoggedIn;
-      },
       currentPage() {
         return pageNameToComponentMap[this.pageName] || null;
       },
@@ -89,42 +63,6 @@
           pageNameToComponentMap[PageNames.TOPICS_TOPIC],
           pageNameToComponentMap[PageNames.TOPICS_CHANNEL],
         ].includes(this.currentPage);
-      },
-      immersivePageProps() {
-        if (this.pageName === PageNames.TOPICS_CONTENT) {
-          let immersivePageRoute = {};
-          let appBarTitle;
-          if (this.topicsTreeContent.parent) {
-            // Need to guard for parent being non-empty to avoid console errors
-            immersivePageRoute = this.$router.getRoute(PageNames.TOPICS_TOPIC, {
-              id: this.topicsTreeContent.parent,
-            });
-
-            if (this.topicsTreeContent.breadcrumbs.length > 0) {
-              appBarTitle = lastItem(this.topicsTreeContent.breadcrumbs).title;
-              immersivePageRoute = this.lastRoute || this.$router.getRoute(PageNames.TOPICS_ROOT);
-            } else {
-              // `breadcrumbs` is empty if the direct parent is the channel, so pull
-              // channel info from state.topicsTree.channel
-              appBarTitle = this.topicsTreeChannel.title;
-            }
-          }
-          return {
-            appBarTitle,
-            immersivePage: true,
-            immersivePageRoute,
-            immersivePagePrimary: true,
-            immersivePageIcon: 'close',
-          };
-        }
-
-        return {
-          appBarTitle: this.exploreString('exploreLabel'),
-          immersivePage: false,
-        };
-      },
-      bottomSpaceReserved() {
-        return 0;
       },
     },
     watch: {


### PR DESCRIPTION
This patch adds a new component to use as base for all explore views.
This component adds the sidebar and one FAB button to show the sidebar.

Inside the custom presentation this will show just a close button to go
back to the channel list.

https://phabricator.endlessm.com/T31231