### PR TITLE
Add app jpg background files to the whl package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,6 +8,7 @@ recursive-exclude kolibri_explore_plugin/* *pyc
 recursive-exclude kolibri_explore_plugin/assets *
 recursive-include kolibri_explore_plugin/templates *.*
 recursive-include kolibri_explore_plugin/apps *.zip
+recursive-include kolibri_explore_plugin/apps *.jpg
 recursive-include kolibri_explore_plugin/static *.*
 recursive-include kolibri_explore_plugin/build *.json
 recursive-include kolibri_explore_plugin/locale *.mo


### PR DESCRIPTION
On [this commit](https://github.com/endlessm/kolibri-explore-plugin/commit/f2a88b23c97ca82706b3d9efb64ccaf5f5bccdde) I forgot to add the `jpg` files to the whl package.