### PR TITLE
Set yarn timeout to 10 minutes

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+network-timeout 600000


### PR DESCRIPTION
The github workflow check usually fails to download the
material-design-icons tarball with a timeout. Let's see
if 10 minutes is enough.

https://phabricator.endlessm.com/T31344