### PR TITLE
Avoid cache in AppView

### DIFF
--- a/kolibri_explore_plugin/urls.py
+++ b/kolibri_explore_plugin/urls.py
@@ -1,5 +1,6 @@
 from django.conf.urls import url
 
+from . import __version__ as VERSION
 from .views import AppFileView
 from .views import AppMetadataView
 from .views import AppView
@@ -7,17 +8,17 @@ from .views import ExploreView
 
 urlpatterns = [
     url(
-        r"^app/static/(?P<app>[\w\-]+)/(?P<filename>[\w\-.]+)",
+        r"^app/%s/static/(?P<app>[\w\-]+)/(?P<filename>[\w\-.]+)" % VERSION,
         AppFileView.as_view(),
         name="app_file",
     ),
     url(
-        r"^app/(?P<app>[\w\-]+)/metadata.json",
+        r"^app/%s/(?P<app>[\w\-]+)/metadata.json" % VERSION,
         AppMetadataView.as_view(),
         name="app_metadata",
     ),
     url(
-        r"^app/(?P<app>[\w\-]+)/(?P<path>.*)?",
+        r"^app/%s/(?P<app>[\w\-]+)/(?P<path>.*)?" % VERSION,
         AppView.as_view(),
         name="app_custom_presentation",
     ),


### PR DESCRIPTION
The cache is done by the browser and even with a fresh built endless
key, the cache in the browser is used to render.

This patch removes the cache_forever and adds a never_cache to avoid
browser caching.

In the future we can think about using the version number in urls to be
able to use the cache_forever, but for now this will fix the known
issues.

https://phabricator.endlessm.com/T31425