### PR TITLE
Use the same url as the learn plugin

### DIFF
--- a/kolibri_explore_plugin/kolibri_plugin.py
+++ b/kolibri_explore_plugin/kolibri_plugin.py
@@ -20,7 +20,7 @@ class Explore(KolibriPluginBase):
 
     @property
     def url_slug(self):
-        return r"explore/"
+        return r"learn/"
 
 
 @register_hook


### PR DESCRIPTION
This plugin will override the learn plugin functionality so we can use
the same url so other tools that does redirects will continue working
when this plugin is enabled.

https://phabricator.endlessm.com/T31247