### PR TITLE
Proxy custom channel for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,31 @@ This approach has advantages to the one above:
 - The development code is the same as the build.
 - No need to edit the plugins text file.
 
+## Custom channel presentation proxy development
+
+Instead of bundle the custom channel presentation bundle inside the apps
+directory, it's possible to work with a proxy for development.
+
+1. Run the custom channel presentation development server without mock data:
+
+```
+$ cd kolibri-channel-custom-web-app/template-ui
+$ VUE_APP_USE_MOCK_DATA=false yarn serve
+```
+
+2. Ensure to run the kolibri devserver with the `PROXY_CUSTOM_CHANNEL` environ
+   enabled:
+
+```
+PROXY_CUSTOM_CHANNEL=1 yarn run devserver-hot
+```
+
+Every request to the custom-channel-ui.zip will be proxied to the devserver.
+Note that the devserver is serving just one custom channel app so every channel
+will show the same custom channel.
+
+The hot reloading should work here too!
+
 Deployment
 ----------
 

--- a/kolibri_explore_plugin/urls.py
+++ b/kolibri_explore_plugin/urls.py
@@ -1,10 +1,16 @@
+import os
+
 from django.conf.urls import url
 
 from . import __version__ as VERSION
 from .views import AppFileView
 from .views import AppMetadataView
-from .views import AppView
 from .views import ExploreView
+
+if os.environ.get("PROXY_CUSTOM_CHANNEL", None):
+    from .views import AppViewDev as AppView
+else:
+    from .views import AppView
 
 urlpatterns = [
     url(

--- a/kolibri_explore_plugin/views.py
+++ b/kolibri_explore_plugin/views.py
@@ -2,13 +2,16 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import io
 import os
 import zipfile
 
+import requests
 from django.http import FileResponse
 from django.http import Http404
 from django.http import HttpResponse
 from django.utils.decorators import method_decorator
+from django.views.decorators.cache import never_cache
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.generic.base import TemplateView
 from django.views.generic.base import View
@@ -61,6 +64,15 @@ class AppView(AppBase):
         response["Accept-Ranges"] = "none"
 
         return response
+
+
+class AppViewDev(AppBase):
+    BASE_APP = "http://localhost:8080/"
+
+    @never_cache
+    def get(self, request, app, path=""):
+        response = requests.get(f"{self.BASE_APP}{path}", stream=True)
+        return FileResponse(io.BytesIO(response.content))
 
 
 class AppFileView(AppBase):


### PR DESCRIPTION
This patch adds a new view that just is a proxy to localhost:8080. This
proxy is used to replace the custom channel presentation zip bundle so
we can preview the result with the custom channel presentation dev
server.

The PROXY_CUSTOM_CHANNEL environ variable should be set on the kolibri
django command environment.

https://phabricator.endlessm.com/T31513