### PR TITLE
Demo: Add Carousel component

### DIFF
--- a/kolibri_explore_plugin/assets/src/components/Carousel.vue
+++ b/kolibri_explore_plugin/assets/src/components/Carousel.vue
@@ -1,0 +1,93 @@
+<template>
+
+  <div>
+    <b-carousel
+      id="carousel"
+      class="carousel"
+      :interval="interval"
+      indicators
+      :imgWidth="width"
+      :imgHeight="height"
+    >
+      <b-carousel-slide
+        v-for="slide in slides"
+        :key="slide.content"
+        :caption="slide.caption"
+        :text="slide.text"
+        :imgSrc="slide.image"
+      >
+        <template #img>
+          <router-link :to="contentLink(slide.content)">
+            <img
+              class="d-block img-fluid w-100"
+              :width="width"
+              :height="height"
+              :src="slide.image"
+            >
+          </router-link>
+        </template>
+      </b-carousel-slide>
+    </b-carousel>
+  </div>
+
+</template>
+
+
+<script>
+
+  import { PageNames } from '../constants';
+
+  export default {
+    name: 'Carousel',
+    props: {
+      slides: {
+        type: Array,
+        default: () => [
+          {
+            caption: 'Example content',
+            image: 'https://picsum.photos/1440/368/?image=54',
+            content: '4adb51edf0e75de6be1c81be58e27a0d',
+          },
+          {
+            image: 'https://picsum.photos/1440/368/?image=23',
+            content: '4adb51edf0e75de6be1c81be58e27a0d',
+          },
+          {
+            image: 'https://picsum.photos/1440/368/?image=43',
+            content: '4adb51edf0e75de6be1c81be58e27a0d',
+          },
+        ],
+      },
+      width: {
+        type: Number,
+        default: 1440,
+      },
+      height: {
+        type: Number,
+        default: 368,
+      },
+      interval: {
+        type: Number,
+        default: 4000,
+      },
+    },
+    methods: {
+      contentLink(content_id) {
+        return {
+          name: PageNames.TOPICS_CONTENT,
+          params: { id: content_id },
+        };
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .carousel {
+    text-shadow: 1px 1px 2px #333333;
+  }
+
+</style>


### PR DESCRIPTION
This component used the bootstrap <b-carousel> component to show a
carousel that links directly to content.

This is an example of use:

<Carousel
  width="1440"
  hegith="368"
  interval="5000"
  :slides="slides"
/>

Slides should be a list of objects with the following parameters:
 * image (required) Link to the image to show
 * content (required) Id of the content to link to
 * caption (optional) Title to show in the slide
 * text (optional) Text to show in the slide

const slides = [
  {
    caption: 'Example content',
    image: 'https://picsum.photos/1440/368/?image=54',
    content: '4adb51edf0e75de6be1c81be58e27a0d',
  },
  ...
];

https://phabricator.endlessm.com/T31544