### PR TITLE
Demo: Add header component

### DIFF
--- a/kolibri_explore_plugin/assets/src/components/Header.vue
+++ b/kolibri_explore_plugin/assets/src/components/Header.vue
@@ -1,0 +1,93 @@
+<template>
+
+  <div id="header">
+    <b-navbar type="dark">
+      <b-navbar-brand href="/learn">
+        <img :src="icon" alt="Endless Key">
+      </b-navbar-brand>
+
+      <b-collapse id="nav-collapse" isNav>
+        <b-navbar-nav>
+          <b-nav-item href="/learn">
+            <b-icon-house-door-fill />
+            Home
+          </b-nav-item>
+          <b-nav-item href="#">
+            Learn
+          </b-nav-item>
+        </b-navbar-nav>
+      </b-collapse>
+
+      <b-navbar-nav class="ml-auto">
+        <div class="searchbar">
+          <label class="visuallyhidden" for="searchfield">Search</label>
+          <input
+            id="searchfield"
+            ref="searchInput"
+            v-model.trim="searchQuery"
+            type="search"
+            class="search-input"
+            dir="auto"
+            placeholder="Search"
+            @focus="searchFocus = true"
+            @blur="searchFocus = false"
+          >
+        </div>
+      </b-navbar-nav>
+    </b-navbar>
+  </div>
+
+</template>
+
+
+<script>
+
+  import placeholder from '../assets/placeholder.png';
+
+  export default {
+    name: 'Header',
+    data() {
+      return {
+        searchQuery: '',
+        searchFocus: false,
+        icon: placeholder,
+      };
+    },
+    watch: {
+      searchQuery() {
+        this.$emit('searchClick', this.searchQuery);
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .searchbar {
+    .search-input {
+      background-color: transparent;
+      border: 0;
+      border-bottom: 1px solid white;
+      opacity: 0.5;
+      transition: all 1s ease;
+
+      &:focus {
+        opacity: 1;
+      }
+    }
+
+    button {
+      transition: all 1s ease;
+    }
+  }
+
+  .navbar-brand img {
+    width: 50px;
+    height: 50px;
+    object-fit: cover;
+    object-position: center;
+  }
+
+</style>

--- a/kolibri_explore_plugin/assets/src/views/Base.vue
+++ b/kolibri_explore_plugin/assets/src/views/Base.vue
@@ -4,22 +4,8 @@
     ref="mainWrapper"
     class="main-wrapper"
   >
-    <SideNav
-      :navShown="navShown"
-      :headerHeight="headerHeight"
-      :width="navWidth"
-      @toggleSideNav="navShown = !navShown"
-    />
-
     <div v-if="!loading" class="explore-main-content">
       <div class="explore-buttons">
-        <KIconButton
-          v-if="!back"
-          icon="menu"
-          size="large"
-          appearance="raised-button"
-          @click="navShown = !navShown"
-        />
         <KIconButton
           v-if="back"
           class="right"
@@ -29,6 +15,7 @@
           @click="goBack()"
         />
       </div>
+
       <slot></slot>
     </div>
   </div>
@@ -41,12 +28,10 @@
   import { mapState } from 'vuex';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import KIconButton from 'kolibri-design-system/lib/buttons-and-links/KIconButton';
-  import SideNav from 'kolibri.coreVue.components.SideNav';
 
   export default {
     name: 'Base',
     components: {
-      SideNav,
       KIconButton,
     },
     mixins: [responsiveWindowMixin],
@@ -56,18 +41,7 @@
         default: false,
       },
     },
-    data() {
-      return {
-        navShown: false,
-      };
-    },
     computed: {
-      headerHeight() {
-        return this.windowIsSmall ? 56 : 64;
-      },
-      navWidth() {
-        return this.headerHeight * 4;
-      },
       ...mapState({
         loading: state => state.core.loading,
       }),

--- a/kolibri_explore_plugin/assets/src/views/ChannelsPage.vue
+++ b/kolibri_explore_plugin/assets/src/views/ChannelsPage.vue
@@ -6,26 +6,7 @@
       class="visuallyhidden"
     />
 
-    <div class="searchbar">
-      <label class="visuallyhidden" for="searchfield">{{ coreString('searchLabel') }}</label>
-      <input
-        id="searchfield"
-        ref="searchInput"
-        v-model.trim="searchQuery"
-        type="search"
-        class="search-input"
-        dir="auto"
-        :placeholder="coreString('searchLabel')"
-        @focus="searchFocus = true"
-        @blur="searchFocus = false"
-      >
-
-      <KIconButton
-        icon="search"
-        :appearance="searchAppareance()"
-        @click="filter"
-      />
-    </div>
+    <Header @searchClick="filter" />
 
     <div class="channelsgrid">
       <ChannelCardGroupGrid
@@ -46,9 +27,9 @@
 
   import { mapState } from 'vuex';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import KIconButton from 'kolibri-design-system/lib/buttons-and-links/KIconButton';
   import { PageNames } from '../constants';
   import Footer from '../components/Footer';
+  import Header from '../components/Header';
   import PageHeader from './PageHeader';
   import ChannelCardGroupGrid from './ChannelCardGroupGrid';
 
@@ -60,16 +41,15 @@
       };
     },
     components: {
-      KIconButton,
       PageHeader,
       ChannelCardGroupGrid,
       Footer,
+      Header,
     },
     mixins: [commonCoreStrings],
     data() {
       return {
         searchQuery: '',
-        searchFocus: false,
       };
     },
     computed: {
@@ -86,11 +66,8 @@
           params: { channel_id },
         };
       },
-      filter() {
-        console.log('search!');
-      },
-      searchAppareance() {
-        return this.searchFocus ? 'raised-button' : 'flat-button';
+      filter(searchQuery) {
+        this.searchQuery = searchQuery;
       },
     },
     $trs: {
@@ -113,27 +90,6 @@
     .channelsgrid {
       padding-top: 40px;
       clear: both;
-    }
-
-    .searchbar {
-      width: 100%;
-      text-align: right;
-
-      .search-input {
-        background-color: transparent;
-        border: 0;
-        border-bottom: 1px solid white;
-        opacity: 0.5;
-        transition: all 1s ease;
-
-        &:focus {
-          opacity: 1;
-        }
-      }
-
-      button {
-        transition: all 1s ease;
-      }
     }
   }
 


### PR DESCRIPTION
This new header component has the endless logo and two links, one for
the home and another fake link with the text "Learn".

The search input has been moved to this new component.

The base component has been updated to remove the SideNav component so
there's no way to see the kolibri sidenav inside the plugin.

https://phabricator.endlessm.com/T31548