### PR TITLE
docker: Add populate script to master image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,14 +17,10 @@ ENV KOLIBRI_CHERRYPY_START=false
 RUN pip install uwsgi
 RUN pip install psycopg2-binary
 RUN pip install kolibri
-RUN pip install kolibri-explore-plugin
-
-# plugin enable
-RUN kolibri plugin enable kolibri.plugins.app
-RUN kolibri plugin disable kolibri.plugins.learn
-RUN kolibri plugin enable kolibri_explore_plugin
 
 COPY uwsgi.ini /docker/uwsgi.ini
 COPY entrypoint.sh /docker/entrypoint.sh
+
+RUN pip install kolibri-explore-plugin
 
 ENTRYPOINT [ "/docker/entrypoint.sh" ]

--- a/docker/Dockerfile-master
+++ b/docker/Dockerfile-master
@@ -1,4 +1,4 @@
-FROM python:3-buster
+FROM python:3.9-buster
 
 EXPOSE 8080
 WORKDIR /docker/
@@ -18,6 +18,9 @@ RUN pip install uwsgi
 RUN pip install psycopg2-binary
 RUN pip install kolibri
 
+COPY uwsgi.ini /docker/uwsgi.ini
+COPY entrypoint.sh /docker/entrypoint.sh
+
 # build and install the master plugin
 RUN apt update
 RUN apt install -y git
@@ -25,11 +28,4 @@ COPY build-plugin.sh /docker/build-plugin.sh
 RUN /docker/build-plugin.sh
 RUN pip install --no-index -f file:///docker/kolibri-explore-plugin/dist kolibri-explore-plugin
 
-# plugin enable
-RUN kolibri plugin enable kolibri.plugins.app
-RUN kolibri plugin disable kolibri.plugins.learn
-RUN kolibri plugin enable kolibri_explore_plugin
-
-COPY uwsgi.ini /docker/uwsgi.ini
-
-ENTRYPOINT [ "uwsgi", "--ini", "uwsgi.ini" ]
+ENTRYPOINT [ "/docker/entrypoint.sh" ]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 
+# plugin enable
+kolibri plugin enable kolibri.plugins.app
+kolibri plugin disable kolibri.plugins.learn
+kolibri plugin enable kolibri_explore_plugin
+
+# Ensure that db is created and updated with the current kolibri version
 kolibri manage migrate
+# Collect statics to ensure they are updated
+kolibri manage collectstatic --clear --noinput
+
 kolibri services --background
 
 uwsgi --ini uwsgi.ini


### PR DESCRIPTION
This PR adds the populate script to the docker image and tries to populate the initial content in the `entrypoint` if it was not populated before. After the population it creates the file `$KOLIBRI_HOME/populated`. If this file exists, the content is not populated, this way we only populate the content once.

https://phabricator.endlessm.com/T31632