### PR TITLE
ContentLightbox: Add Close button

### DIFF
--- a/kolibri_explore_plugin/assets/src/views/ContentItem.vue
+++ b/kolibri_explore_plugin/assets/src/views/ContentItem.vue
@@ -1,0 +1,126 @@
+<template>
+
+  <div>
+    <template v-if="sessionReady">
+      <KContentRenderer
+        class="content-renderer"
+        :kind="contentNode.kind"
+        :lang="contentNode.lang"
+        :files="contentNode.files"
+        :options="contentNode.options"
+        :available="contentNode.available"
+        :extraFields="extraFields"
+        :progress="summaryProgress"
+        :userId="currentUserId"
+        :userFullName="fullName"
+        :timeSpent="summaryTimeSpent"
+        @startTracking="startTracking"
+        @stopTracking="stopTracking"
+        @updateProgress="updateProgress"
+        @addProgress="addProgress"
+        @updateContentState="updateContentState"
+      />
+    </template>
+    <KCircularLoader v-else />
+
+  </div>
+
+</template>
+
+
+<script>
+
+  import { mapState, mapGetters, mapActions } from 'vuex';
+  import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
+  import { updateContentNodeProgress } from '../modules/coreExplore/utils';
+  import commonExploreStrings from './commonExploreStrings';
+
+  export default {
+    name: 'ContentItem',
+    components: {},
+    mixins: [commonExploreStrings],
+    props: {
+      contentNode: {
+        type: Object,
+        required: true,
+      },
+    },
+    data() {
+      return {
+        wasIncomplete: false,
+        sessionReady: false,
+      };
+    },
+    computed: {
+      ...mapGetters(['isUserLoggedIn', 'currentUserId']),
+      ...mapState({
+        masteryAttempts: state => state.core.logging.mastery.totalattempts,
+        summaryProgress: state => state.core.logging.summary.progress,
+        summaryTimeSpent: state => state.core.logging.summary.time_spent,
+        sessionProgress: state => state.core.logging.session.progress,
+        extraFields: state => state.core.logging.summary.extra_fields,
+        fullName: state => state.core.session.full_name,
+      }),
+      progress() {
+        if (this.isUserLoggedIn) {
+          // if there no attempts for this exercise, there is no progress
+          if (this.contentNode.kind === ContentNodeKinds.EXERCISE && this.masteryAttempts === 0) {
+            return null;
+          }
+          return this.summaryProgress;
+        }
+        return this.sessionProgress;
+      },
+    },
+    created() {
+      return this.initSessionAction({
+        channelId: this.contentNode.channel_id,
+        contentId: this.contentNode.content_id,
+        contentKind: this.contentNode.kind,
+      }).then(() => {
+        this.sessionReady = true;
+        this.setWasIncomplete();
+      });
+    },
+    beforeDestroy() {
+      this.stopTracking();
+    },
+    methods: {
+      ...mapActions({
+        initSessionAction: 'initContentSession',
+        updateProgressAction: 'updateProgress',
+        addProgressAction: 'addProgress',
+        startTracking: 'startTrackingProgress',
+        stopTracking: 'stopTrackingProgress',
+        updateContentNodeState: 'updateContentState',
+      }),
+      setWasIncomplete() {
+        this.wasIncomplete = this.progress < 1;
+      },
+      updateProgress(progressPercent, forceSave = false) {
+        this.updateProgressAction({ progressPercent, forceSave }).then(updatedProgressPercent =>
+          updateContentNodeProgress(
+            this.contentNode.channel_id,
+            this.contentNode.id,
+            updatedProgressPercent
+          )
+        );
+        this.$emit('updateProgress', progressPercent);
+      },
+      addProgress(progressPercent, forceSave = false) {
+        this.addProgressAction({ progressPercent, forceSave }).then(updatedProgressPercent =>
+          updateContentNodeProgress(
+            this.contentNode.channel_id,
+            this.contentNode.id,
+            updatedProgressPercent
+          )
+        );
+        this.$emit('addProgress', progressPercent);
+      },
+      updateContentState(contentState, forceSave = true) {
+        this.updateContentNodeState({ contentState, forceSave });
+      },
+    },
+  };
+
+</script>

--- a/kolibri_explore_plugin/assets/src/views/ContentLightbox.vue
+++ b/kolibri_explore_plugin/assets/src/views/ContentLightbox.vue
@@ -1,135 +1,49 @@
 <template>
 
-  <KPageContainer>
-    <KIconButton
-      icon="back"
-      size="large"
-      appearance="raised-button"
-      @click="$emit('close')"
-    />
+  <div class="content-lightbox">
+    <nav>
+      <UiToolbar
+        ref="toolbar"
+        :showIcon="true"
+      >
+        <template #icon>
+          <KIconButton
+            icon="close"
+            @click="$emit('close')"
+          />
+        </template>
 
-    <PageHeader
-      :title="content.title"
-      dir="auto"
-      :contentType="content.kind"
-    />
-    <template v-if="sessionReady">
-      <KContentRenderer
-        class="content-renderer"
-        :kind="content.kind"
-        :lang="content.lang"
-        :files="content.files"
-        :options="content.options"
-        :available="content.available"
-        :extraFields="extraFields"
-        :progress="summaryProgress"
-        :userId="currentUserId"
-        :userFullName="fullName"
-        :timeSpent="summaryTimeSpent"
-        @startTracking="startTracking"
-        @stopTracking="stopTracking"
-        @updateProgress="updateProgress"
-        @addProgress="addProgress"
-        @updateContentState="updateContentState"
-      />
-    </template>
-    <KCircularLoader v-else />
+        <div>
+          {{ content.title }}
+        </div>
+      </UiToolbar>
+    </nav>
 
-    <slot name="below_content">
-    </slot>
-
-  </KPageContainer>
+    <main>
+      <ContentItem :contentNode="content" />
+      <slot name="below_content"></slot>
+    </main>
+  </div>
 
 </template>
 
 
 <script>
 
-  import { mapState, mapGetters, mapActions } from 'vuex';
-  import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
-  import { updateContentNodeProgress } from '../modules/coreExplore/utils';
-  import PageHeader from './PageHeader';
+  import { mapState } from 'vuex';
+  import UiToolbar from 'kolibri.coreVue.components.UiToolbar';
+  import ContentItem from './ContentItem';
   import commonExploreStrings from './commonExploreStrings';
 
   export default {
     name: 'ContentLightbox',
     components: {
-      PageHeader,
+      ContentItem,
+      UiToolbar,
     },
     mixins: [commonExploreStrings],
-    data() {
-      return {
-        wasIncomplete: false,
-        sessionReady: false,
-      };
-    },
     computed: {
-      ...mapGetters(['isUserLoggedIn', 'currentUserId']),
       ...mapState('topicsTree', ['content']),
-      ...mapState('topicsTree', {
-        contentId: state => state.content.content_id,
-        contentNodeId: state => state.content.id,
-        channelId: state => state.content.channel_id,
-      }),
-      ...mapState({
-        masteryAttempts: state => state.core.logging.mastery.totalattempts,
-        summaryProgress: state => state.core.logging.summary.progress,
-        summaryTimeSpent: state => state.core.logging.summary.time_spent,
-        sessionProgress: state => state.core.logging.session.progress,
-        extraFields: state => state.core.logging.summary.extra_fields,
-        fullName: state => state.core.session.full_name,
-      }),
-      progress() {
-        if (this.isUserLoggedIn) {
-          // if there no attempts for this exercise, there is no progress
-          if (this.content.kind === ContentNodeKinds.EXERCISE && this.masteryAttempts === 0) {
-            return null;
-          }
-          return this.summaryProgress;
-        }
-        return this.sessionProgress;
-      },
-    },
-    created() {
-      return this.initSessionAction({
-        channelId: this.channelId,
-        contentId: this.contentId,
-        contentKind: this.content.kind,
-      }).then(() => {
-        this.sessionReady = true;
-        this.setWasIncomplete();
-      });
-    },
-    beforeDestroy() {
-      this.stopTracking();
-    },
-    methods: {
-      ...mapActions({
-        initSessionAction: 'initContentSession',
-        updateProgressAction: 'updateProgress',
-        addProgressAction: 'addProgress',
-        startTracking: 'startTrackingProgress',
-        stopTracking: 'stopTrackingProgress',
-        updateContentNodeState: 'updateContentState',
-      }),
-      setWasIncomplete() {
-        this.wasIncomplete = this.progress < 1;
-      },
-      updateProgress(progressPercent, forceSave = false) {
-        this.updateProgressAction({ progressPercent, forceSave }).then(updatedProgressPercent =>
-          updateContentNodeProgress(this.channelId, this.contentNodeId, updatedProgressPercent)
-        );
-        this.$emit('updateProgress', progressPercent);
-      },
-      addProgress(progressPercent, forceSave = false) {
-        this.addProgressAction({ progressPercent, forceSave }).then(updatedProgressPercent =>
-          updateContentNodeProgress(this.channelId, this.contentNodeId, updatedProgressPercent)
-        );
-        this.$emit('addProgress', progressPercent);
-      },
-      updateContentState(contentState, forceSave = true) {
-        this.updateContentNodeState({ contentState, forceSave });
-      },
     },
   };
 
@@ -138,9 +52,46 @@
 
 <style lang="scss" scoped>
 
-  .content-renderer {
-    // Needs to be one less than the ScrollingHeader's z-index of 4
-    z-index: 3;
+  /* Borrowed from ContentModal in kolibri */
+
+  .content-lightbox {
+    z-index: inherit;
+    width: 80%;
+    max-height: calc(100vh - 80px);
+    margin: 40px auto;
+    overflow: hidden;
+    background: white;
+    border-radius: 4px;
+
+    /deep/ .ui-toolbar {
+      .ui-toolbar__nav-icon {
+        margin-right: 0.5rem;
+      }
+
+      .ui-toolbar__body {
+        margin-right: 1rem;
+      }
+    }
+
+    main {
+      padding: 1rem;
+    }
+  }
+
+  @media (max-width: 960px) {
+    .content-lightbox {
+      width: 90%;
+    }
+  }
+
+  @media (max-width: 600px) {
+    .content-lightbox {
+      width: 100%;
+      height: 100vh;
+      max-height: 100vh;
+      margin: 0;
+      border-radius: 0;
+    }
   }
 
 </style>

--- a/kolibri_explore_plugin/assets/src/views/CustomChannelsPage.vue
+++ b/kolibri_explore_plugin/assets/src/views/CustomChannelsPage.vue
@@ -57,9 +57,13 @@
     bottom: 0;
     left: 0;
 
+    /* Above the sidenav */
+    z-index: 16;
+
     /* With a semi transparent background */
     background: rgba(0, 0, 0, 0.5);
   }
+
   .lightbox {
     /* Center in overlay */
     position: absolute;


### PR DESCRIPTION
This change moves the body part of ContentLightbox into a ContentItem component, as in upstream Kolibri, so we can think about the lightbox independently. I'm tweaking the modal to put a close button alongside the title using the existing UiToolbar component. This isn't _perfect_ (we need to add some extra CSS for UiToolbar to behave itself and it doesn't expect to have an arbitrarily long title). But it feels like a step in the right direction.

https://phabricator.endlessm.com/T31882