### PR TITLE
template: Route to a specific content or topic

### DIFF
--- a/packages/template-ui/src/App.vue
+++ b/packages/template-ui/src/App.vue
@@ -58,9 +58,16 @@ export default {
       this.$store.commit('setHomeNavigation');
       const uri = window.location.search.substring(1);
       const params = new URLSearchParams(uri);
+      // Check if we need to navigate to a specific content or topic. Content takes precedence.
+      const contentId = params.get('contentId');
+      if (contentId) {
+        this.$router.push(`/c/${contentId}`);
+        return;
+      }
       const topicId = params.get('topicId');
       if (topicId) {
-        this.$router.push(`/${topicId}`);
+        this.$router.push(`/t/${topicId}`);
+        return;
       }
     },
   },


### PR DESCRIPTION
The route to a topic was already implemented, but it was broken
because the routes changed. Also, add route to content. If both are
given, content takes precedence.

https://phabricator.endlessm.com/T31936