### PR TITLE
template: Add breadcum to go home from search

### DIFF
--- a/packages/template-ui/src/components/Breadcrumb.vue
+++ b/packages/template-ui/src/components/Breadcrumb.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-if="node.ancestors"
+    v-if="node.ancestors && node.ancestors.length"
   >
     <b-link
       v-for="a in node.ancestors"
@@ -8,6 +8,15 @@
       :to="getTopicUrl(a)"
     >
       <span><b-icon-arrow-left /> {{ a.title }} </span>
+    </b-link>
+  </div>
+  <div
+    v-else-if="notAtHome"
+  >
+    <b-link
+      :to="getNodeUrl(node)"
+    >
+      <span><b-icon-arrow-left /> {{ node.title }} </span>
     </b-link>
   </div>
 </template>
@@ -22,6 +31,9 @@ export default {
   },
   computed: {
     ...mapGetters(['getNodeUrl']),
+    notAtHome() {
+      return this.$route.name !== 'Home';
+    },
   },
   methods: {
     getTopicUrl(n) {


### PR DESCRIPTION
And from any other view that is not Home and that has the default root
node in vuex.

This also fixes the check for ancestors in the breadcum. The v-if
conditional was always true because even the root node has an empty
array of ancestors.

https://phabricator.endlessm.com/T31949