### PR TITLE
Discovery: Add main buttons

### DIFF
--- a/kolibri_explore_plugin/assets/src/modules/coreExplore/mutations.js
+++ b/kolibri_explore_plugin/assets/src/modules/coreExplore/mutations.js
@@ -2,4 +2,7 @@ export default {
   SET_PAGE_NAME(state, name) {
     state.pageName = name;
   },
+  SET_SEARCH_TERM(state, term) {
+    state.searchTerm = term;
+  },
 };

--- a/kolibri_explore_plugin/assets/src/modules/pluginModule.js
+++ b/kolibri_explore_plugin/assets/src/modules/pluginModule.js
@@ -8,6 +8,7 @@ export default {
   state() {
     return {
       pageName: '',
+      searchTerm: '',
     };
   },
   actions,

--- a/kolibri_explore_plugin/assets/src/routes/index.js
+++ b/kolibri_explore_plugin/assets/src/routes/index.js
@@ -16,8 +16,9 @@ export default [
   },
   {
     name: PageNames.SEARCH,
-    path: '/search',
-    handler: () => {
+    path: '/search/:query?',
+    handler: toRoute => {
+      store.commit('SET_SEARCH_TERM', toRoute.params.query);
       store.commit('SET_PAGE_NAME', PageNames.SEARCH);
     },
   },

--- a/kolibri_explore_plugin/assets/src/views/ChannelsPage.vue
+++ b/kolibri_explore_plugin/assets/src/views/ChannelsPage.vue
@@ -7,6 +7,22 @@
       </b-navbar-brand>
 
       <template v-slot:right>
+        <b-nav-text>
+          <strong class="text-muted">Exploration ideas</strong>
+        </b-nav-text>
+
+        <div class="main-buttons">
+          <b-button
+            v-for="term in searchTerms"
+            :key="term"
+            pill
+            variant="primary"
+            @click="goToTerm(term)"
+          >
+            {{ term }}
+          </b-button>
+        </div>
+
         <b-button pill @click="goToSearch">
           <b-icon-search />
           Search
@@ -84,6 +100,11 @@
         default: 3,
       },
     },
+    data() {
+      return {
+        searchTerms: ['STEM', 'Games', 'Fitness', 'Cooking', 'Arts'],
+      };
+    },
     computed: {
       ...mapState('topicsRoot', { channels: 'rootNodes' }),
       // FIXME: filter this correctly, right now we're showing the first 6
@@ -112,6 +133,12 @@
           name: PageNames.SEARCH,
         });
       },
+      goToTerm(term) {
+        this.$router.push({
+          name: PageNames.SEARCH,
+          params: { query: term },
+        });
+      },
     },
   };
 
@@ -137,6 +164,14 @@
 
   .channels-page {
     padding-top: $navbar-height;
+  }
+
+  ::v-deep .main-buttons button {
+    margin-right: $spacer;
+  }
+
+  ::v-deep .main-buttons {
+    margin-left: $spacer;
   }
 
 </style>

--- a/kolibri_explore_plugin/assets/src/views/SearchPage.vue
+++ b/kolibri_explore_plugin/assets/src/views/SearchPage.vue
@@ -103,6 +103,7 @@
       ...mapState('topicsRoot', { searchResult: 'searchResult', channels: 'rootNodes' }),
       ...mapState({
         loading: state => state.core.loading,
+        searchTerm: 'searchTerm',
       }),
       recommended() {
         if (!this.channels || !this.channels.length) {
@@ -166,6 +167,7 @@
       },
     },
     mounted() {
+      this.query = this.searchTerm;
       this.setSearchResult({});
     },
     methods: {


### PR DESCRIPTION
This patch adds five buttons to the discovery page header bar with
predefined search terms, clicking on that button it will open the search
page with that query and will show the results.

https://phabricator.endlessm.com/T31940