### PR TITLE
template: Don't resize thumbnails in content detail view

### DIFF
--- a/packages/template-ui/src/components/ContentImage.vue
+++ b/packages/template-ui/src/components/ContentImage.vue
@@ -7,10 +7,9 @@
       class="play-button position-absolute"
     />
     <b-img
-      fluid
       :src="thumbnail"
       :alt="node.title"
-      class="rounded w-100"
+      class="d-block mx-auto rounded"
     />
   </div>
 </template>


### PR DESCRIPTION
Instead, center the `b-img` horizontally.

https://phabricator.endlessm.com/T32073