### PR TITLE
components: Prevent bubbling click of PlayButtons

### DIFF
--- a/packages/eos-components/src/components/ContentLink.vue
+++ b/packages/eos-components/src/components/ContentLink.vue
@@ -1,8 +1,8 @@
 <template>
   <b-link
     v-b-hover="handleHover"
-    :to="url"
     class="text-decoration-none text-reset"
+    @click="onClick"
   >
     <slot></slot>
   </b-link>
@@ -18,6 +18,9 @@ export default {
   methods: {
     handleHover(hovered) {
       this.$emit('isHovered', hovered);
+    },
+    onClick() {
+      this.$router.push(this.url);
     },
   },
 };

--- a/packages/eos-components/src/components/PlayButton.vue
+++ b/packages/eos-components/src/components/PlayButton.vue
@@ -3,7 +3,7 @@
     pill
     variant="light"
     :class="`card-media-type m-2 ${node.kind}`"
-    @click="$emit('click')"
+    @click.stop="$emit('click')"
   >
     <span class="align-middle">
       <img :src="icon" aria-hidden="true">

--- a/packages/template-ui/src/components/ContentImage.vue
+++ b/packages/template-ui/src/components/ContentImage.vue
@@ -5,6 +5,7 @@
     <PlayButton
       :node="node"
       class="play-button position-absolute"
+      @click="goToContent(node)"
     />
     <b-img
       fluid
@@ -16,6 +17,7 @@
 </template>
 
 <script>
+import { goToContent } from 'kolibri-api';
 import { cardMixin } from 'eos-components';
 
 export default {
@@ -23,6 +25,9 @@ export default {
   mixins: [cardMixin],
   props: {
     node: Object,
+  },
+  methods: {
+    goToContent,
   },
 };
 </script>


### PR DESCRIPTION
Prevent bubbling the click event of PlayButtons using the @click.stop
modifier.

Also, use a click event handler instead of the `:to` in the
ContentLink, which is actually rendered as a
`<router-link>`. Otherwise the event is not stopped.

https://phabricator.endlessm.com/T32063