### PR TITLE
Discovery: Fix search page without searchTerm

### DIFF
--- a/kolibri_explore_plugin/assets/src/views/SearchPage.vue
+++ b/kolibri_explore_plugin/assets/src/views/SearchPage.vue
@@ -166,7 +166,7 @@
       },
     },
     mounted() {
-      this.query = this.searchTerm;
+      this.query = this.searchTerm || '';
       this.setSearchResult({});
     },
     methods: {


### PR DESCRIPTION
The query attribute should be an string always.

https://phabricator.endlessm.com/T31938