### PR TITLE
components: Load style overrides

### DIFF
--- a/channel-overrides.scss
+++ b/channel-overrides.scss
@@ -1,0 +1,1 @@
+/** Empty file, just here to override in template-ui build **/

--- a/packages/eos-components/src/overrides/styles.scss
+++ b/packages/eos-components/src/overrides/styles.scss
@@ -1,0 +1,1 @@
+/** Empty file, just here to override in template-ui build **/

--- a/packages/eos-components/src/styles.scss
+++ b/packages/eos-components/src/styles.scss
@@ -56,6 +56,8 @@ $carousel-indicator-hit-area-height: 10px !default;
 $carousel-indicator-spacer:          3px !default;
 $carousel-indicator-transition:      all .6s ease !default;
 
+@import "../../template-ui/src/overrides/styles.scss";
+
 @import 'bootstrap/scss/bootstrap';
 @import 'bootstrap-vue/src/index';
 

--- a/packages/eos-components/src/styles.scss
+++ b/packages/eos-components/src/styles.scss
@@ -56,7 +56,7 @@ $carousel-indicator-hit-area-height: 10px !default;
 $carousel-indicator-spacer:          3px !default;
 $carousel-indicator-transition:      all .6s ease !default;
 
-@import "../../template-ui/src/overrides/styles.scss";
+@import 'channel-overrides';
 
 @import 'bootstrap/scss/bootstrap';
 @import 'bootstrap-vue/src/index';

--- a/packages/eos-components/vue.config.js
+++ b/packages/eos-components/vue.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  configureWebpack: {
+    resolve: {
+      alias: {
+        'channel-overrides': './overrides/styles.scss',
+      },
+    },
+  },
+};

--- a/packages/template-ui/vue.config.js
+++ b/packages/template-ui/vue.config.js
@@ -5,4 +5,11 @@ module.exports = {
     // FIXME this is because of IE11 compatibility:
     extract: false,
   },
+  configureWebpack: {
+    resolve: {
+      alias: {
+        'channel-overrides': '../../template-ui/src/overrides/styles.scss',
+      },
+    },
+  },
 };


### PR DESCRIPTION
This is hacky because the path is pointing to another package. But the
template is doing the same to load the eos-components dynamically.

https://phabricator.endlessm.com/T32016