### PR TITLE
Discovery page: Add more negative margin to the iframe

### DIFF
--- a/kolibri_explore_plugin/assets/src/views/CustomChannelPresentationApp.vue
+++ b/kolibri_explore_plugin/assets/src/views/CustomChannelPresentationApp.vue
@@ -140,8 +140,8 @@
   .custom-presentation-iframe {
     width: 100%;
     height: 100vh;
-    // Remove 5px for avoiding scrollbar.
-    margin-bottom: -5px;
+    // Remove this arbitrary value for avoiding scrollbar.
+    margin-bottom: -6px;
   }
 
 </style>


### PR DESCRIPTION
One pixel is enough to remove the double scrollbar. Ideally we should
find why this negative margin is needed, but we are not there yet.

https://phabricator.endlessm.com/T32139