### PR TITLE
scripts: Check the TAG release not the TAG commit

### DIFF
--- a/scripts/check_can_relese.sh
+++ b/scripts/check_can_relese.sh
@@ -10,7 +10,7 @@ then
     exit 1
 fi
 
-TAG_HASH=$(git ls-remote https://github.com/endlessm/kolibri-explore-plugin.git $TAG | cut -f1)
+TAG_HASH=$(git ls-remote https://github.com/endlessm/kolibri-explore-plugin.git $TAG^{} | cut -f1)
 if [[ -z $TAG_HASH || $TAG_HASH != $MASTER_HASH ]]
 then
     echo "The tag is not updated or it's not the latest commit in master"


### PR DESCRIPTION
The yarn bump-version command creates a tag with -a so a new object is
created, so the command:

git ls-remote https://github.com/endlessm/kolibri-explore-plugin.git $TAG

Returns the hash of the new tag object and not the head that we want. To
do it correctly we should query the $TAG^{} that resolves to the real
commit pointed by the tag, not to the tag object.

https://phabricator.endlessm.com/T32041