### PR TITLE
Discovery: Make card grid responsive

### DIFF
--- a/kolibri_explore_plugin/assets/src/views/ChannelsPage.vue
+++ b/kolibri_explore_plugin/assets/src/views/ChannelsPage.vue
@@ -89,18 +89,13 @@
   import { mapState } from 'vuex';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import _ from 'underscore';
+  import { responsiveMixin } from 'eos-components';
   import { PageNames } from '../constants';
   import { getBigThumbnail } from '../customApps';
 
   export default {
     name: 'ChannelsPage',
-    mixins: [commonCoreStrings],
-    props: {
-      columns: {
-        type: Number,
-        default: 3,
-      },
-    },
+    mixins: [commonCoreStrings, responsiveMixin],
     data() {
       return {
         searchTerms: ['STEM', 'Games', 'Fitness', 'Cooking', 'Arts'],
@@ -125,6 +120,17 @@
         withThumbnail = _.chunk(withThumbnail, this.columns);
         withoutThumbnail = _.chunk(withoutThumbnail, this.columns);
         return { withThumbnail, withoutThumbnail };
+      },
+      columns() {
+        if (this.xs) {
+          return 1;
+        }
+
+        if (this.sm || this.md) {
+          return 2;
+        }
+
+        return 3;
       },
     },
     methods: {

--- a/kolibri_explore_plugin/assets/src/views/SearchPage.vue
+++ b/kolibri_explore_plugin/assets/src/views/SearchPage.vue
@@ -25,7 +25,7 @@
           <ChannelCardGroup
             :rows="resultChannels"
             :hasThumbnail="false"
-            :columns="3"
+            :columns="columns"
             @card-click="goToChannel"
           />
         </div>
@@ -66,7 +66,7 @@
         </h4>
         <ChannelCardGroup
           :rows="recommended"
-          :columns="3"
+          :columns="columns"
           @card-click="goToChannel"
         />
       </b-container>
@@ -80,7 +80,7 @@
 
   import _ from 'underscore';
   import { mapMutations, mapState } from 'vuex';
-  import { utils, constants } from 'eos-components';
+  import { utils, constants, responsiveMixin } from 'eos-components';
   import { getContentNodeThumbnail } from 'kolibri.utils.contentNode';
 
   import { PageNames } from '../constants';
@@ -88,6 +88,7 @@
 
   export default {
     name: 'SearchPage',
+    mixins: [responsiveMixin],
     data() {
       return {
         query: '',
@@ -113,7 +114,7 @@
         // FIXME: Placeholder recommended channels, randomly selected
         const channels = [];
         const allChannels = [...this.channels];
-        while (channels.length < 3 && allChannels.length > 0) {
+        while (channels.length < this.columns && allChannels.length > 0) {
           const index = _.random(0, allChannels.length - 1);
           const [channel] = allChannels.splice(index, 1);
           channels.push(channel);
@@ -132,7 +133,7 @@
           return null;
         }
 
-        return _.chunk(this.searchResult.channels, 3);
+        return _.chunk(this.searchResult.channels, this.columns);
       },
       resultCards() {
         const { results } = this.searchResult;
@@ -159,6 +160,17 @@
         const grouped = _.groupBy(nodes, n => n.channel_id);
 
         return grouped;
+      },
+      columns() {
+        if (this.xs) {
+          return 1;
+        }
+
+        if (this.sm || this.md) {
+          return 2;
+        }
+
+        return 3;
       },
     },
     watch: {

--- a/packages/eos-components/src/components/SlidableCardGrid.vue
+++ b/packages/eos-components/src/components/SlidableCardGrid.vue
@@ -60,9 +60,11 @@
 <script>
 import _ from 'underscore';
 import { MediaQuality } from '../constants';
+import responsiveMixin from './mixins/responsiveMixin';
 
 export default {
   name: 'SlidableCardGrid',
+  mixins: [responsiveMixin],
   props: {
     nodes: Array,
     mediaQuality: String,
@@ -78,7 +80,13 @@ export default {
   },
   computed: {
     itemsPerSlide() {
-      // FIXME divide by 4 if small screen
+      if (this.xs) {
+        return Math.ceil(this.itemsPerPage / 16);
+      }
+      if (this.sm || this.md) {
+        return Math.ceil(this.itemsPerPage / 8);
+      }
+
       return Math.ceil(this.itemsPerPage / 4);
     },
     slides() {

--- a/packages/eos-components/src/components/mixins/responsiveMixin.js
+++ b/packages/eos-components/src/components/mixins/responsiveMixin.js
@@ -1,0 +1,62 @@
+import { sm, md, lg, xl } from '../../styles.scss';
+
+export default {
+  data() {
+    return {
+      xs: false,
+      sm: false,
+      md: false,
+      lg: false,
+      xl: false,
+      xsQueryList: null,
+      smQueryList: null,
+      mdQueryList: null,
+      lgQueryList: null,
+      xlQueryList: null,
+    };
+  },
+  created() {
+    this.xsQueryList = window.matchMedia(`(max-width: ${sm})`);
+    this.smQueryList = window.matchMedia(`(min-width: ${sm}) and (max-width: ${md})`);
+    this.mdQueryList = window.matchMedia(`(min-width: ${md}) and (max-width: ${lg})`);
+    this.lgQueryList = window.matchMedia(`(min-width: ${lg}) and (max-width: ${xl})`);
+    this.xlQueryList = window.matchMedia(`(min-width: ${xl})`);
+
+    this.xsQueryList.addListener(this.onXsChange);
+    this.smQueryList.addListener(this.onSmChange);
+    this.mdQueryList.addListener(this.onMdChange);
+    this.lgQueryList.addListener(this.onLgChange);
+    this.xlQueryList.addListener(this.onXlChange);
+
+    // First launch
+    this.onXsChange(this.xsQueryList);
+    this.onSmChange(this.smQueryList);
+    this.onMdChange(this.mdQueryList);
+    this.onLgChange(this.lgQueryList);
+    this.onXlChange(this.xlQueryList);
+  },
+  destroyed() {
+    this.xsQueryList.removeListener(this.onXsChange);
+    this.smQueryList.removeListener(this.onSmChange);
+    this.mdQueryList.removeListener(this.onMdChange);
+    this.lgQueryList.removeListener(this.onLgChange);
+    this.xlQueryList.removeListener(this.onXlChange);
+  },
+  methods: {
+    onXsChange(ev) {
+      this.xs = ev.matches;
+    },
+    onSmChange(ev) {
+      this.sm = ev.matches;
+    },
+    onMdChange(ev) {
+      this.md = ev.matches;
+    },
+    onLgChange(ev) {
+      this.lg = ev.matches;
+    },
+    onXlChange(ev) {
+      this.xl = ev.matches;
+    },
+  },
+};

--- a/packages/eos-components/src/main.js
+++ b/packages/eos-components/src/main.js
@@ -23,6 +23,7 @@ import SlidableCardGrid from './components/SlidableCardGrid.vue';
 import TopicCard from './components/TopicCard.vue';
 
 import cardMixin from './components/mixins/cardMixin.js';
+import responsiveMixin from './components/mixins/responsiveMixin.js';
 
 import utils from './utils.js';
 import constants from './constants.js';
@@ -64,6 +65,7 @@ const plugin = {
 export {
   components,
   cardMixin,
+  responsiveMixin,
   utils,
   constants,
   plugin as default,

--- a/packages/eos-components/src/styles.scss
+++ b/packages/eos-components/src/styles.scss
@@ -64,3 +64,11 @@ $carousel-indicator-transition:      all .6s ease !default;
 $navbar-height: $navbar-brand-height +
                 $navbar-brand-padding-y * 2 +
                 $navbar-padding-y * 2;
+
+:export {
+  xs: map-get($grid-breakpoints, "xs");
+  sm: map-get($grid-breakpoints, "sm");
+  md: map-get($grid-breakpoints, "md");
+  lg: map-get($grid-breakpoints, "lg");
+  xl: map-get($grid-breakpoints, "xl");
+}


### PR DESCRIPTION
This patch makes the discovery page card grid and search grids
responsive, showing three cards for large screens, two for small and
one for really small screens.

A new mixin was introduced to calculate the column width and also to
change the width data in the component on resize, so it can be used to
change inside components properties.

The bootstrap sass breakpoints are also exposed in the styles.scss so it
can be used inside the javascript to determine at witch point to change
the number of elements to show.

https://phabricator.endlessm.com/T32160