### PR TITLE
Template: Make ChannelHeader responsive

### DIFF
--- a/packages/eos-components/src/components/ChannelLogo.vue
+++ b/packages/eos-components/src/components/ChannelLogo.vue
@@ -63,7 +63,7 @@
   }
 
   .lg {
-    $size: 128px;
+    $size: 96px;
     min-height: $size;
     min-width: $size;
     max-height: $size;
@@ -73,7 +73,7 @@
   }
 
   .xl {
-    $size: 248px;
+    $size: 128px;
     min-height: $size;
     min-width: $size;
     max-height: $size;

--- a/packages/template-ui/src/components/ChannelHeader.vue
+++ b/packages/template-ui/src/components/ChannelHeader.vue
@@ -6,14 +6,22 @@
   >
     <template v-slot:default>
       <div class="align-items-start d-flex justify-content-between mt-3">
-        <h1>{{ section.title }}</h1>
-        <ChannelLogo v-if="displayLogoInHeader" :channel="channel" size="lg" />
       </div>
       <b-row>
-        <b-col md="6" sm="12">
+        <b-col xs="12" sm="8" md="9" lg="9" xl="8">
+          <h1 class="d-md-none h3">
+            {{ section.title }}
+          </h1>
+          <h1 class="d-md-block d-none">
+            {{ section.title }}
+          </h1>
           <div class="lead mb-2 text-muted">
             {{ headerDescription }}
           </div>
+        </b-col>
+        <b-col v-if="displayLogoInHeader" class="d-none d-sm-flex justify-content-end">
+          <ChannelLogo class="d-lg-none d-none d-sm-block" :channel="channel" size="lg" />
+          <ChannelLogo class="d-lg-block d-none" :channel="channel" size="xl" />
         </b-col>
       </b-row>
     </template>

--- a/packages/template-ui/src/components/ChannelHeader.vue
+++ b/packages/template-ui/src/components/ChannelHeader.vue
@@ -7,7 +7,7 @@
     <template v-slot:default>
       <div class="align-items-start d-flex justify-content-between mt-3">
         <h1>{{ section.title }}</h1>
-        <ChannelLogo :channel="channel" size="lg" />
+        <ChannelLogo v-if="displayLogoInHeader" :channel="channel" size="lg" />
       </div>
       <b-row>
         <b-col md="6" sm="12">
@@ -21,7 +21,7 @@
 </template>
 
 <script>
-import { mapGetters } from 'vuex';
+import { mapState, mapGetters } from 'vuex';
 
 import headerMixin from '@/components/mixins/headerMixin';
 
@@ -29,6 +29,7 @@ export default {
   name: 'ChannelHeader',
   mixins: [headerMixin],
   computed: {
+    ...mapState(['displayLogoInHeader']),
     ...mapGetters(['headerDescription']),
   },
 };

--- a/packages/template-ui/src/components/mixins/headerMixin.js
+++ b/packages/template-ui/src/components/mixins/headerMixin.js
@@ -10,7 +10,7 @@ export default {
     };
   },
   computed: {
-    ...mapState(['channel', 'section', 'displayLogoInHeader']),
+    ...mapState(['channel', 'section']),
     ...mapGetters(['getAssetURL']),
     sectionImageURL() {
       if (!this.section || !this.section.title) {


### PR DESCRIPTION
Some improvements in the ChannelHeader logo to work correctly in different screen sizes.

In this PR the ChannelHeader uses the bootstrap col sizes to resize depending on the windows size. The channel logo is also reduced when the screen is smaller and also the title uses the `h3` class for small screens.


https://phabricator.endlessm.com/T32102