### PR TITLE
template: Make navbar and header backgrounds match

### DIFF
--- a/packages/eos-components/src/mixins.scss
+++ b/packages/eos-components/src/mixins.scss
@@ -37,3 +37,19 @@
     }
   }
 }
+
+// Allows reusing the same style in the header and in the navbar:
+@mixin navbar-background($header-height) {
+  background-color: $header-color;
+  background-attachment: fixed;
+  background-position: top center;
+  background-repeat: no-repeat;
+
+  @include media-breakpoint-down(xxl) {
+    background-size: auto $header-height;
+  }
+
+  @include media-breakpoint-up(xxl) {
+    background-size: 100% auto;
+  }
+}

--- a/packages/eos-components/src/styles.scss
+++ b/packages/eos-components/src/styles.scss
@@ -30,6 +30,15 @@ $theme-colors: (
   "video": $orange
 );
 
+$grid-breakpoints: (
+  xs: 0,
+  sm: 576px,
+  md: 768px,
+  lg: 992px,
+  xl: 1200px,
+  xxl: 2560px
+) !default;
+
 $btn-font-weight: 600;
 $headings-font-weight: 600;
 $display1-weight: 700;
@@ -57,6 +66,7 @@ $breadcrumb-bg: $secondary !default;
 
 // Template variables:
 $header-logo-width: 128;
+$header-height: 300px; // FIXME to be defined exactly in https://phabricator.endlessm.com/T32150
 $hover-lightness: -25%;
 $background-alpha: -8%;
 
@@ -155,4 +165,5 @@ $navbar-height: $navbar-brand-height +
   md: map-get($grid-breakpoints, "md");
   lg: map-get($grid-breakpoints, "lg");
   xl: map-get($grid-breakpoints, "xl");
+  xxl: map-get($grid-breakpoints, "xxl");
 }

--- a/packages/template-ui/src/components/ChannelHeader.vue
+++ b/packages/template-ui/src/components/ChannelHeader.vue
@@ -47,10 +47,10 @@ export default {
 @import '@/styles.scss';
 
 .jumbotron {
-  background-color: $header-color;
-  background-size: cover;
-  background-position: top center;
+  @include navbar-background($header-height);
   padding-top: $navbar-height;
+  height: $header-height;
+  padding-bottom: $navbar-height;
 }
 
 img {

--- a/packages/template-ui/src/components/ChannelNavBar.vue
+++ b/packages/template-ui/src/components/ChannelNavBar.vue
@@ -41,9 +41,7 @@ export default {
 @import '@/styles.scss';
 
 .header {
-  background-color: $header-color;
-  background-size: cover !important;
-  background-repeat: no-repeat !important;
+  @include navbar-background($header-height);
 }
 
 img {


### PR DESCRIPTION
The header has to have a fixed height for this to work.

For smaller screens, the logic changes to stretch the center part of
the background.

https://phabricator.endlessm.com/T32175