### PR TITLE
template: Make navbar breadcrumb responsive

### DIFF
--- a/packages/template-ui/src/components/Breadcrumb.vue
+++ b/packages/template-ui/src/components/Breadcrumb.vue
@@ -1,28 +1,43 @@
 <template>
   <b-navbar-nav
-    v-if="(node.ancestors && node.ancestors.length) || notAtHome"
     class="mt-3"
     aria-label="breadcrumb"
   >
-    <ChannelLogo class="mt-1" :channel="channel" size="sm" />
+    <ChannelLogo class="d-none d-sm-block mt-1" :channel="channel" size="sm" />
     <ol
       v-if="node.ancestors && node.ancestors.length"
       class="bg-transparent breadcrumb px-2"
     >
-      <li
-        v-for="a in node.ancestors"
-        :key="a.id"
-        class="breadcrumb-item"
-      >
-        <b-link
-          :to="getTopicUrl(a)"
+      <template v-if="xs || sm">
+        <li v-if="node.ancestors.length > 1" class="active breadcrumb-item">
+          ...
+        </li>
+        <li
+          class="breadcrumb-item"
         >
-          {{ a.title }}
-        </b-link>
-      </li>
+          <b-link
+            :to="getTopicUrl(parentNode)"
+          >
+            {{ parentNode.title }}
+          </b-link>
+        </li>
+      </template>
+      <template v-else>
+        <li
+          v-for="a in node.ancestors"
+          :key="a.id"
+          class="breadcrumb-item"
+        >
+          <b-link
+            :to="getTopicUrl(a)"
+          >
+            {{ a.title }}
+          </b-link>
+        </li>
+      </template>
     </ol>
     <ol
-      v-else-if="notAtHome"
+      v-else
       class="bg-transparent breadcrumb px-2"
     >
       <li class="breadcrumb-item">
@@ -37,19 +52,24 @@
 </template>
 
 <script>
-import { utils } from 'eos-components';
+import { utils , responsiveMixin } from 'eos-components';
 import { mapState } from 'vuex';
+
 
 export default {
   name: 'Breadcrumb',
+  mixins: [responsiveMixin],
   props: {
     node: Object,
   },
   computed: {
     ...mapState(['channel']),
-    notAtHome() {
-      return this.$route.name !== 'Home';
-    },
+    parentNode() {
+      if (!this.node.ancestors || !this.node.ancestors.length) {
+        return null;
+      }
+      return this.node.ancestors[this.node.ancestors.length-1];
+    }
   },
   methods: {
     getTopicUrl(n) {
@@ -61,12 +81,3 @@ export default {
   },
 };
 </script>
-
-<style lang="scss" scoped>
-@import '@/styles.scss';
-
-// .breadcrumb {
-//  background-color: transparent;
-// }
-
-</style>

--- a/packages/template-ui/src/components/ChannelNavBar.vue
+++ b/packages/template-ui/src/components/ChannelNavBar.vue
@@ -4,7 +4,7 @@
     :style="{ backgroundImage: headerImageURL }"
     @click-logo="goToChannelList"
   >
-    <Breadcrumb :node="node" />
+    <Breadcrumb v-if="notAtHome" :node="node" />
   </Header>
 </template>
 
@@ -24,6 +24,9 @@ export default {
       }
 
       return this.section;
+    },
+    notAtHome() {
+      return this.$route.name !== 'Home';
     },
   },
   methods: {


### PR DESCRIPTION
- Show only the last parent for XS and SM breakpoints.
- Hide channel logo for XS breakpoint.

Also:

- Move the "notAtHome" conditional to the navbar.
- Remove commented style.

https://phabricator.endlessm.com/T32096