### PR TITLE
template: Fix lint error on Section

### DIFF
--- a/packages/template-ui/src/views/Section.vue
+++ b/packages/template-ui/src/views/Section.vue
@@ -25,10 +25,9 @@ export default {
     }),
     sectionVariant() {
       if (this.showAsBundle(this.section) && this.isSimpleBundle) {
-        return 'BundleSection'
-      } else {
-        return 'ListSection'
+        return 'BundleSection';
       }
+      return 'ListSection';
     },
   },
   methods: {


### PR DESCRIPTION
This change was introduced as part of the PR #130:
https://github.com/endlessm/kolibri-explore-plugin/pull/130/files#diff-188f7b897a1e20b9d5f7891fe048bc8b7868578210d30dbc5d7600575edf7199R26-R31

And the lint CI didn't complain there, but I'm getting some errors when
trying to run the development instance about "no-else-return":
https://eslint.org/docs/rules/no-else-return

This patch just fixes that issue and also adds the trailing `;` to the
two "return" lines.

https://phabricator.endlessm.com/T31752