### PR TITLE
template: Add options to remove elements from home view

### DIFF
--- a/packages/eos-components/src/components/CardGrid.vue
+++ b/packages/eos-components/src/components/CardGrid.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-container class="mb-5 section-container">
+  <b-container class="mb-5 mt-4 section-container">
     <slot></slot>
 
     <component

--- a/packages/template-ui/channel-overrides/pbs-kids/options.json
+++ b/packages/template-ui/channel-overrides/pbs-kids/options.json
@@ -1,4 +1,7 @@
 {
   "displayLogoInHeader": false,
+  "hasSectionsSearch": false,
+  "hasCarousel": false,
+  "hasFilters": false,
   "bundleKind": "simple"
 }

--- a/packages/template-ui/src/components/SectionsSearchRow.vue
+++ b/packages/template-ui/src/components/SectionsSearchRow.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-container class="align-items-center d-flex py-4">
+  <b-container class="align-items-center d-flex my-4">
     <MainSections />
     <b-button-toolbar class="align-self-end ml-auto" keyNav aria-label="Search">
       <b-button-group

--- a/packages/template-ui/src/store/index.js
+++ b/packages/template-ui/src/store/index.js
@@ -66,6 +66,9 @@ const initialState = {
 
   mediaQuality: ComponentConstants.MediaQuality.REGULAR,
   displayLogoInHeader: true,
+  hasSectionsSearch: true,
+  hasCarousel: true,
+  hasFilters: true,
   isEndlessApp: false,
   bundleKind: null,
 };

--- a/packages/template-ui/src/views/Home.vue
+++ b/packages/template-ui/src/views/Home.vue
@@ -3,19 +3,19 @@
     :style="{ backgroundImage: backgroundImageURL }"
   >
     <slot></slot>
-    <SectionsSearchRow />
+    <SectionsSearchRow v-if="hasSectionsSearch" />
 
-    <div v-if="loading">
-      <CarouselPlaceholder />
+    <template v-if="loading">
+      <CarouselPlaceholder v-if="hasCarousel" />
       <CardGridPlaceholder />
-    </div>
+    </template>
 
-    <div v-else>
-      <Carousel :nodes="carouselNodes" />
-      <b-container>
+    <template v-else>
+      <Carousel v-if="hasCarousel" :nodes="carouselNodes" />
+      <b-container v-if="hasCarousel">
         <hr>
       </b-container>
-      <FilterContent />
+      <FilterContent v-if="hasFilters" />
 
       <div v-if="isFilterEmpty">
         <CardGrid
@@ -45,7 +45,7 @@
         <FilterResult :node="section" />
       </div>
 
-    </div>
+    </template>
   </div>
 </template>
 
@@ -64,6 +64,9 @@ export default {
       'loading',
       'cardColumns',
       'mediaQuality',
+      'hasSectionsSearch',
+      'hasCarousel',
+      'hasFilters',
     ]),
     ...mapGetters({
       mainSections: 'mainSections',


### PR DESCRIPTION
The elements that can be removed by the overrides are:

- The row with main sections and search button.
- The carousel.
- The filter row.

Also, make the PBS-Kids override use all of them.

Also, improve the margins and replace divs with templates so the
margins count.

https://phabricator.endlessm.com/T31752