### PR TITLE
Components: Do not use css min property

### DIFF
--- a/packages/eos-components/src/components/CarouselCard.vue
+++ b/packages/eos-components/src/components/CarouselCard.vue
@@ -98,11 +98,15 @@ export default {
 }
 .card {
   border-radius: $border-radius-lg;
-  padding-left: min(400px, 50%);
   position: relative;
   background-color: $gray-700;
   color: $white;
   border: none;
+
+  padding-left: $carousel-image-width;
+  @include media-breakpoint-up(lg) {
+    padding-left: $carousel-image-lg-width;
+  }
 }
 .img {
   border-top-left-radius: $border-radius-lg;
@@ -111,10 +115,14 @@ export default {
   left: 0;
   bottom: 0;
   top: 0;
-  width: min(400px, 50%);
   background-repeat: no-repeat;
   background-size: cover;
   background-position: center;
+
+  width: $carousel-image-width;
+  @include media-breakpoint-up(lg) {
+    width: $carousel-image-lg-width;
+  }
 }
 
 .card-content h2 {

--- a/packages/eos-components/src/styles.scss
+++ b/packages/eos-components/src/styles.scss
@@ -117,6 +117,9 @@ $carousel-indicator-hit-area-height: 10px !default;
 $carousel-indicator-spacer:          3px !default;
 $carousel-indicator-transition:      all .6s ease !default;
 
+$carousel-image-width:    50%;
+$carousel-image-lg-width: 400px;
+
 @import "../../template-ui/src/overrides/styles.scss";
 
 @import 'bootstrap/scss/bootstrap';


### PR DESCRIPTION
This property is not supported in old browsers. This patch replaces the
min property with breakpoint styles, so it's 50% for xs, sm and md and
400px for the rest.

https://phabricator.endlessm.com/T32184