### PR TITLE
Discovery page: Fix offset in html5_viewer icon

### DIFF
--- a/kolibri_explore_plugin/assets/src/views/ContentItem.vue
+++ b/kolibri_explore_plugin/assets/src/views/ContentItem.vue
@@ -156,3 +156,16 @@
   };
 
 </script>
+
+
+<style lang="scss" scoped>
+
+  @import '../styles';
+
+  // Fix icon offset in the Kolibri plugins:
+  .content-renderer::v-deep .button img,
+  .content-renderer::v-deep .button svg {
+    vertical-align: baseline;
+  }
+
+</style>


### PR DESCRIPTION
The header bar with the fullscreen icon is not inside an iframe, so
our CSS affects it. This is a workaround to compensate the offset.

https://phabricator.endlessm.com/T32186