### PR TITLE
template: Add grid for simple bundle page

### DIFF
--- a/packages/template-ui/src/components/ContentImage.vue
+++ b/packages/template-ui/src/components/ContentImage.vue
@@ -8,6 +8,7 @@
       @click="goToContent(node)"
     />
     <b-img
+      fluid
       :src="thumbnail"
       :alt="node.title"
       class="d-block mx-auto rounded"

--- a/packages/template-ui/src/views/BundleSection.vue
+++ b/packages/template-ui/src/views/BundleSection.vue
@@ -2,7 +2,7 @@
   <div>
     <b-container class="main-container">
       <b-row class="mt-3">
-        <b-col md="6" sm="12">
+        <b-col md="4" sm="12">
           <h3>{{ section.title }}</h3>
           <p class="mb-2">
             {{ subtitle }}
@@ -10,18 +10,25 @@
           <!-- eslint-disable vue/no-v-html -->
           <div class="description mb-2" v-html="section.description"></div>
         </b-col>
-        <b-col md="6" sm="12">
-          <div
-            v-for="content in section.children"
-            :key="content.id"
-            class="mb-3"
-          >
-            <b-link
-              @click="goToContent(content)"
+        <b-col
+          md="8"
+          sm="12"
+        >
+          <b-row>
+            <b-col
+              v-for="content in section.children"
+              :key="content.id"
+              class="content-col"
+              md="6"
+              sm="12"
             >
-              <ContentImage :node="content" />
-            </b-link>
-          </div>
+              <b-link
+                @click="goToContent(content)"
+              >
+                <ContentImage :node="content" />
+              </b-link>
+            </b-col>
+          </b-row>
         </b-col>
       </b-row>
     </b-container>
@@ -64,6 +71,10 @@ export default {
   background-color: $white;
   background-size: cover;
   padding-top: $navbar-height;
+}
+
+.content-col {
+  margin-bottom: $grid-gutter-width;
 }
 
 </style>


### PR DESCRIPTION
Add a nested grid to display 2 content images per row in medium size
screens and above. In small screens it all is piled vertically.

Make the content images "fluid" so they adjust to the container space.

Use the gutter width variable (defaults to 30px) for the bottom
margin, to have the same gutter between rows than between columns.

https://phabricator.endlessm.com/T32075