### PR TITLE
Components: Remove placeholder-loading dependency

### DIFF
--- a/packages/eos-components/package.json
+++ b/packages/eos-components/package.json
@@ -14,7 +14,6 @@
     "bootstrap": "^4.5.3",
     "bootstrap-vue": "^2.21.2",
     "core-js": "^3.6.5",
-    "placeholder-loading": "^0.4.0",
     "vue": "^2.6.11",
     "vue-clamp": "^0.3.1",
     "vue-material-design-icons": "^4.12.1"

--- a/packages/eos-components/src/components/CardGridPlaceholder.vue
+++ b/packages/eos-components/src/components/CardGridPlaceholder.vue
@@ -5,19 +5,17 @@
         v-for="item in items"
         :key="item"
         borderVariant="light"
+        noBody
+        imgTop
       >
-        <div class="ph-item">
-          <div class="card-img ph-picture"></div>
-          <div class="ph-col-12">
-            <div class="ph-row">
-              <div class="big ph-col-12"></div>
-              <div class="ph-col-12"></div>
-              <div class="ph-col-12"></div>
-              <div class="empty ph-col-12"></div>
-              <div class="big ph-col-4"></div>
-            </div>
-          </div>
-        </div>
+        <b-skeleton-img cardImg="top" />
+        <b-card-body class="d-flex flex-column">
+          <b-skeleton width="85%" />
+          <b-skeleton width="55%" />
+          <b-skeleton width="35%" />
+
+          <b-skeleton class="mt-5" type="button" />
+        </b-card-body>
       </b-card>
     </b-card-group>
   </b-container>
@@ -42,19 +40,4 @@
 
 <style lang="scss" scoped>
   @import '../styles.scss';
-  @import 'placeholder-loading/src/scss/placeholder-loading.scss';
-
-  .ph-item {
-    min-height: card-body-height(3);
-  }
-
-  .card-body, .ph-item {
-    padding: 0;
-  }
-
-  $card-image-ar: 9 / 16;
-  .card-img {
-    padding-top: percentage($card-image-ar);
-    height: 0;
-  }
 </style>

--- a/packages/eos-components/src/components/CarouselPlaceholder.vue
+++ b/packages/eos-components/src/components/CarouselPlaceholder.vue
@@ -1,28 +1,17 @@
 <template>
   <b-container class="mb-4">
-    <!-- carousel -->
-    <div class="ph-item">
-      <div class="ph-col-6">
-        <div class="ph-picture"></div>
-      </div>
-      <div class="ph-col-6">
-        <div class="ph-row">
-          <div class="big ph-col-6"></div>
-          <div class="big empty ph-col-6"></div>
+    <b-card noBody imgLeft>
+      <b-skeleton-img cardImg="left" />
+      <b-card-body class="d-flex flex-column">
+        <b-skeleton width="85%" />
+        <b-skeleton width="55%" />
 
-          <div class="ph-col-12"></div>
-          <div class="ph-col-8"></div>
-          <div class="empty ph-col-4"></div>
-          <div class="ph-col-12"></div>
-          <div class="ph-col-6"></div>
-          <div class="empty ph-col-6"></div>
-
-          <div class="empty ph-col-12"></div>
-          <div class="empty ph-col-12"></div>
-          <div class="big ph-col-2"></div>
+        <div class="align-items-center d-flex justify-content-between mt-auto">
+          <b-skeleton width="20%" />
+          <b-skeleton type="button" />
         </div>
-      </div>
-    </div>
+      </b-card-body>
+    </b-card>
   </b-container>
 </template>
 
@@ -34,12 +23,18 @@
 
 <style lang="scss" scoped>
   @import '../styles.scss';
-  @import 'placeholder-loading/src/scss/placeholder-loading.scss';
 
-  .ph-item {
-    min-height: card-body-height(5);
+  .card > .b-aspect {
+    width: $carousel-image-width;
+    @include media-breakpoint-up(lg) {
+      width: $carousel-image-lg-width;
+    }
   }
-  .ph-picture {
-    height: 100%;
+
+  .b-skeleton-text {
+    height: $h4-font-size * $headings-line-height;
+    @include media-breakpoint-up(lg) {
+      height: $h2-font-size * $headings-line-height;
+    }
   }
 </style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -13636,11 +13636,6 @@ pkg-up@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-placeholder-loading@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/placeholder-loading/-/placeholder-loading-0.4.0.tgz#bef86521d614ab76bfeff17cb4872f281d023116"
-  integrity sha512-Po3XESQ/rKy9WKJSmHV7xSvW9y7hl8y0YBWG6By6zdiP4xkSPSpYPxbUlL0m3WqMI4oBnt/eQMlRwo9OVgJHVQ==
-
 pn@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"


### PR DESCRIPTION
This patch removes the placeholder-loading dependency and uses the
bootstrap-vue skeleton component to do that.

https://phabricator.endlessm.com/T32183