### PR TITLE
Remove close button shadow and white border for videos

### DIFF
--- a/kolibri_explore_plugin/assets/src/views/ContentModal.vue
+++ b/kolibri_explore_plugin/assets/src/views/ContentModal.vue
@@ -99,7 +99,7 @@
 
   // This is overriding the Kolibri media player plugin:
   ::v-deep .content-renderer {
-    border: 0;
+    border: 0 !important;
   }
 
   ::v-deep .modal-footer {

--- a/packages/eos-components/src/styles.scss
+++ b/packages/eos-components/src/styles.scss
@@ -138,6 +138,10 @@ $carousel-image-lg-width: 400px;
   color: $dark;
 }
 
+.close.text-light {
+  text-shadow: none;
+}
+
 // Change header color:
 $header-color: scale-color($secondary, $lightness: 50%);
 


### PR DESCRIPTION
The existing border override needs `!important` to apply in all cases.

https://phabricator.endlessm.com/T32185