### PR TITLE
Discovery: Hide loading screen beforeDestroy

### DIFF
--- a/kolibri_explore_plugin/assets/src/views/CustomChannelPresentationApp.vue
+++ b/kolibri_explore_plugin/assets/src/views/CustomChannelPresentationApp.vue
@@ -50,6 +50,7 @@
     },
     beforeDestroy() {
       window.removeEventListener('message', this.onMessage);
+      this.$emit('load');
     },
     methods: {
       onMessage(event) {


### PR DESCRIPTION
To avoid the loading screen to be shown forever, this patch adds the
'load' signal emission before destroy the component, so if the component
is destroyed before the 'load' signal is emitted, the loading screen
will be hidden anyway.

https://phabricator.endlessm.com/T32210