### PR TITLE
template: Improve backgrounds again

### DIFF
--- a/packages/eos-components/src/mixins.scss
+++ b/packages/eos-components/src/mixins.scss
@@ -44,12 +44,8 @@
   background-attachment: fixed;
   background-position: top center;
   background-repeat: no-repeat;
-
-  @include media-breakpoint-down(xxl) {
+  background-size: 100% auto;
+  @include media-breakpoint-down(md) {
     background-size: auto $header-height;
-  }
-
-  @include media-breakpoint-up(xxl) {
-    background-size: 100% auto;
   }
 }

--- a/packages/eos-components/src/styles.scss
+++ b/packages/eos-components/src/styles.scss
@@ -44,7 +44,6 @@ $grid-breakpoints: (
   md: 768px,
   lg: 992px,
   xl: 1200px,
-  xxl: 2560px
 ) !default;
 
 $btn-font-weight: 600;
@@ -74,7 +73,7 @@ $breadcrumb-bg: $secondary !default;
 
 // Template variables:
 $header-logo-width: 128;
-$header-height: 300px; // FIXME to be defined exactly in https://phabricator.endlessm.com/T32150
+$header-height: 349px; // Forms an area with the LG breakpoint of aspect ratio: 2.8444
 $hover-lightness: -25%;
 $background-alpha: -8%;
 
@@ -170,7 +169,6 @@ $navbar-height: $navbar-brand-height +
   md: map-get($grid-breakpoints, "md");
   lg: map-get($grid-breakpoints, "lg");
   xl: map-get($grid-breakpoints, "xl");
-  xxl: map-get($grid-breakpoints, "xxl");
 }
 
 .description {


### PR DESCRIPTION
Use the LG breakpoint (down md) and assume that background assets will
have 2.8444 aspect ratio. Same AR as the header at exactly the LG
breakpoint. So the header height is adjusted as well.

- Below LG: the background is displayed full height.
- LG and up: the background is displayed full width.

Also, remove the unused xxl breakpoint.

https://phabricator.endlessm.com/T32175