### PR TITLE
template: Improve backgrounds again

### DIFF
--- a/packages/eos-components/src/mixins.scss
+++ b/packages/eos-components/src/mixins.scss
@@ -44,12 +44,8 @@
   background-attachment: fixed;
   background-position: top center;
   background-repeat: no-repeat;
-
-  @include media-breakpoint-down(xxl) {
+  background-size: 100% auto;
+  @include media-breakpoint-down(xl) {
     background-size: auto $header-height;
-  }
-
-  @include media-breakpoint-up(xxl) {
-    background-size: 100% auto;
   }
 }

--- a/packages/eos-components/src/styles.scss
+++ b/packages/eos-components/src/styles.scss
@@ -44,7 +44,7 @@ $grid-breakpoints: (
   md: 768px,
   lg: 992px,
   xl: 1200px,
-  xxl: 2560px
+  xxl: 1400px,
 ) !default;
 
 $btn-font-weight: 600;
@@ -74,7 +74,7 @@ $breadcrumb-bg: $secondary !default;
 
 // Template variables:
 $header-logo-width: 128;
-$header-height: 300px; // FIXME to be defined exactly in https://phabricator.endlessm.com/T32150
+$header-height: 496px; // Forms an area with the XXL breakpoint of aspect ratio: 2.82
 $hover-lightness: -25%;
 $background-alpha: -8%;
 


### PR DESCRIPTION
Use the XXL breakpoint (down xl) and assume that background assets
will have 2.82 aspect ratio. Same AR as the header at exactly the LG
breakpoint. So the header height is adjusted as well.

- Below XXL: the background is displayed full height.
- XXL and up: the background is displayed full width.

https://phabricator.endlessm.com/T32175