### PR TITLE
content renderer: Remove fullscreen bar for T2 games

### DIFF
--- a/kolibri_explore_plugin/assets/src/customApps.js
+++ b/kolibri_explore_plugin/assets/src/customApps.js
@@ -30,6 +30,10 @@ export const ThumbApps = [
   'healthy-mind',
 ];
 
+export const GameAppIDs = [
+  '3160899a73564d8a8467284d9219b91c', // Terminal Two
+];
+
 export function getBigThumbnail(channel) {
   if (!channel.title) {
     return null;

--- a/kolibri_explore_plugin/assets/src/views/ContentItem.vue
+++ b/kolibri_explore_plugin/assets/src/views/ContentItem.vue
@@ -5,6 +5,7 @@
       <KContentRenderer
         v-if="!content.assessment"
         class="content-renderer"
+        :class="{ 'without-fullscreen-bar': withoutFullscreenBar }"
         :kind="content.kind"
         :lang="content.lang"
         :files="content.files"
@@ -26,6 +27,7 @@
         v-else
         :id="content.id"
         class="content-renderer"
+        :class="{ 'without-fullscreen-bar': withoutFullscreenBar }"
         :kind="content.kind"
         :files="content.files"
         :lang="content.lang"
@@ -59,6 +61,7 @@
   import { mapState, mapGetters, mapActions } from 'vuex';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import { updateContentNodeProgress } from '../modules/coreExplore/utils';
+  import { GameAppIDs } from '../customApps';
   import AssessmentWrapper from './AssessmentWrapper';
   import commonExploreStrings from './commonExploreStrings';
 
@@ -103,6 +106,9 @@
           return this.summaryProgress;
         }
         return this.sessionProgress;
+      },
+      withoutFullscreenBar() {
+        return GameAppIDs.includes(this.content.channel_id);
       },
     },
     created() {
@@ -170,6 +176,10 @@
   .content-renderer::v-deep .button img,
   .content-renderer::v-deep .button svg {
     vertical-align: baseline;
+  }
+
+  .content-renderer.without-fullscreen-bar::v-deep .fullscreen-header {
+    display: none;
   }
 
   .content-item--dark::v-deep .content-renderer .fullscreen-header {


### PR DESCRIPTION
Add a GameAppIDs array constant to store all the channels that need
the fullscreen bar removed. For now it's just the Terminal Two
channel.

Use the array to add a CSS class to the content renderer, and add a
display: hidden rule to it.

https://phabricator.endlessm.com/T32242