### PR TITLE
T32187 fullscreen icon tweaks

### DIFF
--- a/kolibri_explore_plugin/assets/src/views/ContentItem.vue
+++ b/kolibri_explore_plugin/assets/src/views/ContentItem.vue
@@ -182,6 +182,16 @@
     display: none;
   }
 
+  // Tweak fullscreen icons to look nicer here
+  .content-renderer::v-deep .fullscreen-header {
+    .fullscreen-button svg,
+    .button .fs-icon {
+      top: 5px;
+      width: 20px;
+      height: 20px;
+    }
+  }
+
   .content-item--dark::v-deep .content-renderer .fullscreen-header {
     color: $gray-300;
     background-color: $lightbox-toolbar !important;

--- a/kolibri_explore_plugin/assets/src/views/ContentItem.vue
+++ b/kolibri_explore_plugin/assets/src/views/ContentItem.vue
@@ -211,6 +211,19 @@
         fill: $gray-300 !important;
       }
     }
+
+    .ui-icon-button {
+      color: $gray-300;
+      background: none;
+
+      &:hover {
+        background-color: lighten($lightbox-toolbar, 10%) !important;
+      }
+
+      svg {
+        fill: $gray-300;
+      }
+    }
   }
 
 </style>

--- a/kolibri_explore_plugin/assets/src/views/ContentModal.vue
+++ b/kolibri_explore_plugin/assets/src/views/ContentModal.vue
@@ -9,7 +9,7 @@
     :title="content.title"
     headerCloseVariant="light"
   >
-    <ContentItem dark :content="content" />
+    <ContentItem isDark :content="content" />
   </b-modal>
 
 </template>


### PR DESCRIPTION
This pull request corrects some small errors in content toolbars:

- Icon buttons in a dark styled toolbar (the "+" and "-" buttons in the document viewer) have their colours set accordingly.
- Full-screen button icons are sized consistently (and vertically aligned with their text).

![Screenshot 2021-07-08 at 15-38-39 PhET Interactive Simulations (English)](https://user-images.githubusercontent.com/132063/125004361-39ded180-e00e-11eb-9b07-d75bbba4f191.png)
![Screenshot 2021-07-08 at 15-39-12 Canal de Patatas](https://user-images.githubusercontent.com/132063/125004362-3a776800-e00e-11eb-835e-5a09e2ac354c.png)
![Screenshot 2021-07-08 at 16-47-44 How to get started with Kolibri on Endless OS](https://user-images.githubusercontent.com/132063/125004363-3b0ffe80-e00e-11eb-93dd-80bc0cc56c09.png)

https://phabricator.endlessm.com/T32187