### PR TITLE
Components: Fix thumbnail async load

### DIFF
--- a/packages/eos-components/src/components/mixins/cardMixin.js
+++ b/packages/eos-components/src/components/mixins/cardMixin.js
@@ -23,7 +23,7 @@ export default {
   },
   methods: {
     getThumbnail() {
-      if (!this.node.thumbnail || this.node.useDefaultThumbnail) {
+      if (!this.node.thumbnail && this.node.useDefaultThumbnail) {
         this.thumbnail = this.getAsset('defaultThumbnail');
         return;
       }


### PR DESCRIPTION
This patch fixes a regression introduced in the following commit:
https://github.com/endlessm/kolibri-explore-plugin/commit/beb2a48d375d0a5fc902e4068b8e35c82d655e4c

It shows the default thumbnail always in custom channels. This patch
fixes that in brings back the content thumbnail async load.

https://phabricator.endlessm.com/T32077