### PR TITLE
Discovery: Add loading state to search

### DIFF
--- a/kolibri_explore_plugin/assets/src/views/SearchPage.vue
+++ b/kolibri_explore_plugin/assets/src/views/SearchPage.vue
@@ -14,7 +14,6 @@
       <SearchBar
         v-model="query"
         :debounce="800"
-        :loading="isLoading"
         @clear-input="clearInput"
       />
       <b-container class="pb-5 pt-3">
@@ -28,6 +27,9 @@
             :buttons="searchTerms"
             @click="goToTerm"
           />
+        </div>
+        <div v-if="isLoading" class="placeholder">
+          <CardGridPlaceholder />
         </div>
         <div v-if="resultChannels">
           <h4 class="text-muted">

--- a/packages/eos-components/src/components/SearchBar.vue
+++ b/packages/eos-components/src/components/SearchBar.vue
@@ -9,9 +9,14 @@
           </b-input-group-text>
         </template>
         <template #append>
-          <span v-if="value" @click="clearSearchInput">
-            <b-icon-x />
-          </span>
+          <b-button
+            v-if="value"
+            variant="link"
+            class="text-muted"
+            @click="clearSearchInput"
+          >
+            <b-icon-x-circle scale="2" />
+          </b-button>
         </template>
         <input
           ref="searchInput"
@@ -78,6 +83,7 @@
     border: none;
     box-shadow: none;
   }
+  font-size: $h5-font-size;
 }
 
 .input-group-text {
@@ -88,7 +94,6 @@
 .search-row {
   background-color: $white;
   margin-bottom: $jumbotron-padding;
-  box-shadow: $btn-active-box-shadow;
 }
 
 </style>


### PR DESCRIPTION
This patch adds the placeholder cards instead of the loading spinner in
the discovery search page.

It also includes some css changes to the searchbar:

 * Clean button restyled, bigger and with a circle
 * Larger text for the input

https://phabricator.endlessm.com/T32246