### PR TITLE
template: Ellipsize the header description

### DIFF
--- a/packages/template-ui/src/components/ChannelHeader.vue
+++ b/packages/template-ui/src/components/ChannelHeader.vue
@@ -1,8 +1,9 @@
 <template>
   <b-jumbotron
     fluid
-    :style="{ backgroundImage: headerImageURL }"
+    :style="{ backgroundImage: (isDescriptionExpanded ? 'none' : headerImageURL) }"
     class="mb-0"
+    :class="{ 'full-height': isDescriptionExpanded, 'has-image': hasHeaderImage }"
   >
     <template v-slot:default>
       <div class="align-items-start d-flex justify-content-between mt-3">
@@ -25,7 +26,27 @@
             class="lead mb-2"
             :class="{ 'text-light': hasDarkHeader, 'text-muted': !hasDarkHeader }"
           >
-            {{ headerDescription }}
+            <VClamp
+              autoresize
+              :maxLines="maxDescriptionLines"
+              :expanded.sync="isDescriptionExpanded"
+            >
+              {{ headerDescription }}
+              <template #after="{ toggle, expanded, clamped }">
+                <br>
+                <b-button
+                  v-if="expanded || clamped"
+                  href="#"
+                  pill
+                  :variant="hasHeaderImage ? 'primary' : 'secondary'"
+                  size="sm"
+                  class="mt-1"
+                  @click.prevent="toggle"
+                >
+                  {{ expanded ? 'Show less' : 'Show more' }}
+                </b-button>
+              </template>
+            </VClamp>
           </div>
         </b-col>
         <b-col v-if="displayLogoInHeader" class="d-none d-sm-flex justify-content-end">
@@ -39,12 +60,22 @@
 
 <script>
 import { mapState, mapGetters } from 'vuex';
+import VClamp from 'vue-clamp';
 
 import headerMixin from '@/components/mixins/headerMixin';
 
 export default {
   name: 'ChannelHeader',
+  components: {
+    VClamp,
+  },
   mixins: [headerMixin],
+  data() {
+    return {
+      maxDescriptionLines: 6,  // Actually 5. One more for the show more/less button.
+      isDescriptionExpanded: false,
+    };
+  },
   computed: {
     ...mapState(['displayLogoInHeader', 'hasDarkHeader']),
     ...mapGetters(['headerDescription']),
@@ -58,8 +89,14 @@ export default {
 .jumbotron {
   @include navbar-background($header-height);
   padding-top: $navbar-height;
-  height: $header-height;
+  min-height: $header-height;
   padding-bottom: $navbar-height;
+  &.full-height {
+    min-height: auto;
+  }
+  &.has-image {
+    background-color: $primary;
+  }
 }
 
 img {

--- a/packages/template-ui/src/components/ChannelNavBar.vue
+++ b/packages/template-ui/src/components/ChannelNavBar.vue
@@ -2,6 +2,7 @@
   <Header
     class="header"
     :style="{ backgroundImage: headerImageURL }"
+    :class="{ 'has-image': hasHeaderImage }"
     :showLogo="showLogo"
     @click-logo="goToChannelList"
   >
@@ -47,6 +48,9 @@ export default {
 
 .header {
   @include navbar-background($header-height);
+  &.has-image {
+    background-color: $primary;
+  }
 }
 
 img {

--- a/packages/template-ui/src/components/mixins/headerMixin.js
+++ b/packages/template-ui/src/components/mixins/headerMixin.js
@@ -27,6 +27,9 @@ export default {
     headerImageURL() {
       return this.sectionImageURL || this.getAssetURL('headerImage');
     },
+    hasHeaderImage() {
+      return this.headerImageURL !== null;
+    },
   },
   methods: {
     getSlug,


### PR DESCRIPTION
And add a button to enlarge the header and show all the description
when it ellipsizes. Per design, we cut at 5 lines.

Also: when a channel has an image asset in the header, use the primary
color instead of the secondary color as fallback. This makes the
background look better in case Endless curated channels do ellipsize
their description (very unlikely). Add a hasHeaderImage computed
property to the mixin for this.

https://phabricator.endlessm.com/T32294