### PR TITLE
components: Move logo inside the margins for header

### DIFF
--- a/packages/eos-components/src/components/Header.vue
+++ b/packages/eos-components/src/components/Header.vue
@@ -1,7 +1,7 @@
 <template>
   <b-navbar class="header" :class="{ shadow: hasScrolled }" fixed="top">
     <b-container class="px-3">
-      <img class="logo" :src="logo" @click="$emit('click-logo')">
+      <img v-if="showLogo" class="logo" :src="logo" @click="$emit('click-logo')">
       <slot></slot>
 
       <b-navbar-nav class="ml-auto">
@@ -17,6 +17,12 @@
 
   export default {
     name: 'Header',
+    props: {
+      showLogo: {
+        type: Boolean,
+        default: true,
+      },
+    },
     data() {
       return {
         hasScrolled: false,
@@ -57,23 +63,10 @@
   }
 
   $logo-size: 50px;
-  // 2.27 is the AR of the endless logo
-  $logo-height: $logo-size / 2.27;
   .logo {
-    position: absolute;
-    margin-left: - ($logo-size + 20px);
-    margin-top: - ($logo-height / 2);
-    top: 50%;
-
+    margin-right: $spacer;
     width: $logo-size;
     cursor: pointer;
-
-    @include media-breakpoint-down(sm) {
-      position: inherit;
-      margin-left: 0;
-      margin-top: 0;
-      margin-right: $spacer;
-    }
   }
 
 </style>

--- a/packages/template-ui/src/components/ChannelNavBar.vue
+++ b/packages/template-ui/src/components/ChannelNavBar.vue
@@ -2,6 +2,7 @@
   <Header
     class="header"
     :style="{ backgroundImage: headerImageURL }"
+    :showLogo="showLogo"
     @click-logo="goToChannelList"
   >
     <Breadcrumb v-if="notAtHome" :node="node" />
@@ -9,13 +10,14 @@
 </template>
 
 <script>
+import { responsiveMixin } from 'eos-components';
 import { mapState } from 'vuex';
 import headerMixin from '@/components/mixins/headerMixin';
 import { goToChannelList } from 'kolibri-api';
 
 export default {
   name: 'ChannelNavBar',
-  mixins: [headerMixin],
+  mixins: [headerMixin, responsiveMixin],
   computed: {
     ...mapState(['content']),
     node() {
@@ -27,6 +29,9 @@ export default {
     },
     notAtHome() {
       return this.$route.name !== 'Home';
+    },
+    showLogo() {
+      return !(this.xs && this.node.ancestors.length);
     },
   },
   methods: {


### PR DESCRIPTION
This patch removes the negative margin for the Endless logo in the
header, so now the logo will be inside the container, like any other
component.

The negative margin is something that doesn't work correctly with
different screen sizes because the margin is not fixed and can be
smaller than the logo size.

With this change we loose the effect of the logo at the left of the
content with the scroll, but if makes it work correctly with diffrent
sizes.

This patch also hides the endless logo for "xs" sizes, showing it only
if there's no breadcrumb.

https://phabricator.endlessm.com/T32279