### PR TITLE
T32306 async load

### DIFF
--- a/kolibri_explore_plugin/assets/src/apiResources.js
+++ b/kolibri_explore_plugin/assets/src/apiResources.js
@@ -1,3 +1,5 @@
+import _ from 'underscore';
+
 import { Resource } from 'kolibri.lib.apiResource';
 import Store from 'kolibri.coreVue.vuex.store';
 
@@ -35,6 +37,28 @@ export const ContentNodeResource = new Resource({
   },
   fetchNextSteps(getParams) {
     return this.fetchDetailCollection('next_steps', Store.getters.currentUserId, getParams);
+  },
+  fetchChannelAsync(channelId, parent = null) {
+    // Fetch all content for a channel recursively, making a request to the
+    // backend for each level in the nodes tree
+    const getParams = {
+      channel_id: channelId,
+      parent: parent || channelId,
+    };
+
+    return this.fetchCollection({ getParams }).then(n => {
+      return Promise.all(n).then(nodes => {
+        const promises = nodes
+          .filter(node => node.kind === 'topic')
+          .map(node => this.fetchChannelAsync(channelId, node.id));
+
+        return Promise.all(promises).then(array => {
+          return new Promise(resolve => {
+            resolve(_.union(nodes, _.flatten(array)));
+          });
+        });
+      });
+    });
   },
 });
 

--- a/kolibri_explore_plugin/assets/src/customApps.js
+++ b/kolibri_explore_plugin/assets/src/customApps.js
@@ -18,6 +18,7 @@ export const CustomChannelApps = {
   fc47aee82e0153e2a30197d3fdee1128: 'open-stax',
   '74f36493bb475b62935fa8705ed59fed': 'thoughtful-learning',
   '1e378725d3924b47aa5e1260628820b5': 'ted-ed-lessons',
+  '922e9c576c2f59e59389142b136308ff': 'career-girls',
 };
 
 export function getAppNameByID(id) {
@@ -29,7 +30,7 @@ export const ThumbApps = [
   'music',
   'ted-ed-lessons',
   'common-sense-student-resources',
-  'carreer-girls',
+  'career-girls',
   'cspathshala',
   'touchable-earth',
   'oceanx',

--- a/packages/kolibri-api/index.js
+++ b/packages/kolibri-api/index.js
@@ -49,9 +49,8 @@ export function goToContent(node) {
   window.parent.postMessage(message, '*');
 }
 
-export function askChannelInformation(callback) {
+export function askChannelInformation(callback, fetchAsync = false) {
   window.addEventListener('message', (event) => {
-    // console.log(event);
     if (event.data.event && event.data.nameSpace === 'hashi'
               && event.data.event === 'sendChannelInformation') {
       callback(event.data.data);
@@ -60,7 +59,7 @@ export function askChannelInformation(callback) {
 
   const nameSpace = 'customChannelPresentation';
   const event = 'askChannelInformation';
-  const data = null;
+  const data = { fetchAsync };
   const message = {
     event,
     data,

--- a/packages/template-ui/channel-overrides/career-girls/options.json
+++ b/packages/template-ui/channel-overrides/career-girls/options.json
@@ -1,0 +1,3 @@
+{
+  "fetchAsync": true
+}

--- a/packages/template-ui/src/App.vue
+++ b/packages/template-ui/src/App.vue
@@ -13,10 +13,13 @@
 
 <script>
 import { askChannelInformation } from 'kolibri-api';
-import { mapMutations } from 'vuex';
+import { mapMutations, mapState } from 'vuex';
 
 export default {
   name: 'App',
+  computed: {
+    ...mapState(['fetchAsync']),
+  },
   watch: {
     $route(to) {
       // Watch the router "to" parameter, and set the navigation state accordingly.
@@ -39,7 +42,7 @@ export default {
     },
   },
   created() {
-    askChannelInformation(this.gotChannelInformation);
+    askChannelInformation(this.gotChannelInformation, this.fetchAsync);
   },
   methods: {
     ...mapMutations(['setContentNavigation', 'setSectionNavigation', 'setHomeNavigation']),

--- a/packages/template-ui/src/store/index.js
+++ b/packages/template-ui/src/store/index.js
@@ -74,6 +74,7 @@ const initialState = {
   displayHeroContent: false,
   isEndlessApp: false,
   bundleKind: null,
+  fetchAsync: false,
 };
 
 const store = new Vuex.Store({
@@ -92,7 +93,6 @@ const store = new Vuex.Store({
             return n;
           });
         state.nodes = [rootNode, ...contentNodes];
-        state.tree = getNodesTree(state.nodes);
       } else {
         state.nodes = parsedNodes;
       }

--- a/packages/template-ui/src/views/Section.vue
+++ b/packages/template-ui/src/views/Section.vue
@@ -30,9 +30,5 @@ export default {
       return 'ListSection';
     },
   },
-  methods: {
-    ...mapGetters({
-    }),
-  },
 };
 </script>


### PR DESCRIPTION
The career-girls channel has a lot of content and the backend fails when we try to fetch all nodes with:

```
django.db.utils.OperationalError: Expression tree is too large (maximum depth 1000)
```
For channels like that, instead of querying all the content in one request it's possible to get the same data with one request per topic.

https://phabricator.endlessm.com/T32306