### PR TITLE
template: Fix detail page for flat channels

### DIFF
--- a/packages/template-ui/src/store/index.js
+++ b/packages/template-ui/src/store/index.js
@@ -88,7 +88,7 @@ const store = new Vuex.Store({
           .filter((n) => n.kind !== 'topic')
           .map((n) => {
             n.parent = rootNode.id;
-            n.ancestors = [rootNode.id];
+            n.ancestors = [rootNode];
             return n;
           });
         state.nodes = [rootNode, ...contentNodes];


### PR DESCRIPTION
The array of ancestors should be of node objects, not node IDs.

https://phabricator.endlessm.com/T32310