### PR TITLE
discovery page: Add synonyms to search terms

### DIFF
--- a/kolibri_explore_plugin/assets/src/constants.js
+++ b/kolibri_explore_plugin/assets/src/constants.js
@@ -27,4 +27,14 @@ export const CUSTOM_PRESENTATION_TITLE = 'custom-channel-ui';
 
 export const CarouselItems = 5;
 
-export const searchTerms = ['STEM', 'Games', 'Fitness', 'Cooking', 'Arts'];
+export const searchTerms = new Map([
+  ['Arts', 'artist music painting drawing arts'],
+  ['Careers', 'career college degrees personality'],
+  ['Cooking', 'recipes desserts meat vegetables bread culinary'],
+  ['Fitness', 'fitness yoga workout'],
+  ['Games', 'games gamers gaming the maze'],
+  ['Maths', 'mathematics'],
+  ['Music', 'blues rhythm ukulele guitar beatbox'],
+  ['Science', 'cool science sciences physics biology molecules gravity'],
+  ['Sports', 'football soccer dribbling volley tennis skating'],
+]);

--- a/kolibri_explore_plugin/assets/src/views/ChannelsPage.vue
+++ b/kolibri_explore_plugin/assets/src/views/ChannelsPage.vue
@@ -10,7 +10,7 @@
         <ButtonsBar
           class="mr-3 mt-1"
           title="More Topics"
-          :buttons="searchTerms"
+          :buttons="Array.from(searchTerms.keys())"
           @click="goToTerm"
         />
         <SearchButton @click="goToSearch" />
@@ -118,9 +118,10 @@
         });
       },
       goToTerm(term) {
+        const query = searchTerms.get(term) || term;
         this.$router.push({
           name: PageNames.SEARCH,
-          params: { query: term },
+          params: { query },
         });
       },
       getBigThumbnail(channel) {

--- a/kolibri_explore_plugin/assets/src/views/SearchPage.vue
+++ b/kolibri_explore_plugin/assets/src/views/SearchPage.vue
@@ -31,7 +31,7 @@
             </h5>
             <ButtonsBar
               title="More Topics"
-              :buttons="searchTerms"
+              :buttons="Array.from(searchTerms.keys())"
               @click="goToTerm"
             />
           </div>
@@ -240,7 +240,7 @@
         });
       },
       goToTerm(term) {
-        this.query = term;
+        this.query = searchTerms.get(term) || term;
       },
       search(query) {
         if (!query) {


### PR DESCRIPTION
To get better results from the backend, in particular for the main
buttons.

Also, update the list of search terms.

It's using a Map to ensure order.

https://phabricator.endlessm.com/T32320