### PR TITLE
components: Use always 3 max lines for topic description

### DIFF
--- a/packages/eos-components/src/components/TopicCard.vue
+++ b/packages/eos-components/src/components/TopicCard.vue
@@ -30,7 +30,6 @@
               <VClamp
                 autoresize
                 :maxLines="titleMaxLines"
-                @clampchange="(e) => isTitleClamped = e"
               >
                 {{ node.title }}
               </VClamp>
@@ -78,7 +77,7 @@ export default {
   data() {
     return {
       isHovered: false,
-      isTitleClamped: false,
+      descriptionMaxLines: 3,
       thumbnailProps: { width: ThumbnailSize.width, height: ThumbnailSize.height },
     };
   },
@@ -100,12 +99,6 @@ export default {
       }
       return 2;
     },
-    descriptionMaxLines() {
-      if (this.isTitleClamped) {
-        return 3;
-      }
-      return 4;
-    }
   },
 };
 </script>


### PR DESCRIPTION
In T32077 we made the false assumption that 4 lines of description
would fit when the title is not clamped, and 3 otherwise. But the
title can have 2 lines and still not clamp.

So we have no option but using 3 max lines always for the description.

https://phabricator.endlessm.com/T32326