### PR TITLE
discovery page: Use Poppins font for buttons

### DIFF
--- a/kolibri_explore_plugin/assets/src/views/ExploreIndex.vue
+++ b/kolibri_explore_plugin/assets/src/views/ExploreIndex.vue
@@ -101,16 +101,19 @@
   @import '../index';
 
   .partial-fonts-loaded body,
-  .partial-fonts-loaded button,
   .partial-fonts-loaded input,
   .partial-fonts-loaded select,
   .partial-fonts-loaded textarea,
   .full-fonts-loaded body,
-  .full-fonts-loaded button,
   .full-fonts-loaded input,
   .full-fonts-loaded select,
   .full-fonts-loaded textarea {
     font-family: $font-family-sans-serif;
+  }
+
+  .partial-fonts-loaded button,
+  .full-fonts-loaded button {
+    font-family: $headings-font-family;
   }
 
   /** Non scoped styles to be able to modify body css to fix the footer to the bottom **/


### PR DESCRIPTION
This is because we have to override all the font rules from the
Kolibri standard theme, which adds Noto to many elements.

https://phabricator.endlessm.com/T32302