### PR TITLE
discovery page: Fix console error for inexistent variable

### DIFF
--- a/kolibri_explore_plugin/assets/src/views/ChannelsPage.vue
+++ b/kolibri_explore_plugin/assets/src/views/ChannelsPage.vue
@@ -24,7 +24,7 @@
     </b-container>
 
     <template v-if="core.loading">
-      <CarouselPlaceholder v-if="hasCarousel" />
+      <CarouselPlaceholder />
     </template>
 
     <template v-else>


### PR DESCRIPTION
It seems this was copy/pasted from the template carousel, which has an
override option to have/not have the carousel.

https://phabricator.endlessm.com/T32371