### PR TITLE
components: Cards: Don't show tags when showing channel info

### DIFF
--- a/packages/eos-components/src/components/CardBody.vue
+++ b/packages/eos-components/src/components/CardBody.vue
@@ -15,7 +15,7 @@
     <p v-else class="mb-1 subtitle text-muted text-truncate">
       {{ subtitle }}
     </p>
-    <div v-if="tags.length" class="mb-3 tags text-truncate">
+    <div v-if="showTags" class="mb-3 tags text-truncate">
       <b-badge
         v-for="tag in tags"
         :key="tag"
@@ -66,6 +66,9 @@ export default {
     },
     showChannelIcon() {
       return this.node.channel;
+    },
+    showTags() {
+      return !this.showChannelIcon && this.tags.length;
     },
   },
 };


### PR DESCRIPTION
These were never intended to be displayed at the same time.

https://phabricator.endlessm.com/T32360