### PR TITLE
Components: Style Carousel card to avoid button wrap

### DIFF
--- a/packages/eos-components/src/components/CarouselCard.vue
+++ b/packages/eos-components/src/components/CarouselCard.vue
@@ -14,12 +14,18 @@
               {{ node.title }}
             </VClamp>
           </h4>
-          <div class="d-flex justify-content-between">
+          <div class="align-items-center d-flex justify-content-between">
             <div v-if="showChannelIcon" class="align-items-center d-flex">
               <ChannelLogo class="mr-2" :channel="node.channel" size="sm" />
-              <span class="text-muted">{{ node.channel.title }}</span>
+              <span class="d-md-block d-none pr-2 text-muted text-truncate">
+                {{ node.channel.title }}
+              </span>
             </div>
-            <p v-else class="align-self-center mb-1 subtitle text-muted text-truncate">
+            <p
+              v-else
+              :class="`align-self-center d-none d-sm-block
+                       mb-1 pr-2 subtitle text-muted text-truncate`"
+            >
               {{ subtitle }}
             </p>
             <PlayButton

--- a/packages/eos-components/src/components/PlayButton.vue
+++ b/packages/eos-components/src/components/PlayButton.vue
@@ -3,7 +3,7 @@
     pill
     size="sm"
     :variant="`${kind}-${variant}`"
-    class="border-0 pb-1 pl-1 play-button pt-1"
+    class="border-0 pb-1 pl-1 play-button pt-1 text-nowrap"
     @click.stop="$emit('click')"
   >
     <component


### PR DESCRIPTION
This patch set the style property nowrap to ensure that we always have
the icon and the text aligned in the PlayButton component.

It also adds some style classes to improve the responsiveness for the
CarouselCard, hidding the subtitle when there's no space.

https://phabricator.endlessm.com/T32389