### PR TITLE
template: Don't overuse the channel card in the footer

### DIFF
--- a/packages/eos-components/src/components/ChannelCard.vue
+++ b/packages/eos-components/src/components/ChannelCard.vue
@@ -42,7 +42,7 @@
         type: String,
         default: 'basicCard',
         validator: (value) => {
-          return ['basicCard', 'infoCard', 'smallCard'].indexOf(value) !== -1;
+          return ['basicCard', 'smallCard'].indexOf(value) !== -1;
         },
       },
     },
@@ -75,15 +75,6 @@
 
 <style lang="scss" scoped>
   @import '../styles';
-
-  .infoCard {
-    background-color: transparent !important;
-    border: 0 !important;
-  }
-
-  .infoCard .card-body {
-    padding: 0 !important;
-  }
 
   .smallCard,
   .basicCard {

--- a/packages/template-ui/src/components/ChannelFooter.vue
+++ b/packages/template-ui/src/components/ChannelFooter.vue
@@ -2,7 +2,13 @@
   <div class="text-muted">
     <Footer>
       <template #left>
-        <ChannelCard :channel="channel" variant="infoCard" />
+        <div class="align-items-center d-flex pb-3">
+          <ChannelLogo class="mr-3" :channel="channel" size="md" />
+          <h6>{{ channel.title }}</h6>
+        </div>
+        <p class="pt-2">
+          {{ channel.description }}
+        </p>
       </template>
       <template #right>
         <div v-if="isEndlessApp" class="endless-seal text-right">


### PR DESCRIPTION
In this case doing composition is a bit forced because it's not
actually a card, so it doesn't need ellipsizing at max lines. Also,
using composition we had to add too much CSS, it was more complicated.

Also, remove the infoCard variant of ChannelCard.

https://phabricator.endlessm.com/T32388