### PR TITLE
plugin: Add ancestors to nodes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,10 @@ repos:
   hooks:
   - id: trailing-whitespace
   - id: flake8
+    args:
+      # make flake8 compatible with black:
+      - "--max-line-length=88"
+      - "--ignore=E203,W503"
   - id: check-yaml
   - id: check-added-large-files
     args: ['--maxkb=2000']

--- a/kolibri_explore_plugin/viewsets.py
+++ b/kolibri_explore_plugin/viewsets.py
@@ -1,11 +1,40 @@
 from kolibri.core.content.api import ContentNodeSearchViewset
 from kolibri.core.content.api import ContentNodeViewset
+from kolibri.core.content.models import ContentNode
 from kolibri.core.content.models import ContentTag
 from rest_framework.decorators import list_route
 from rest_framework.response import Response
 
 
 class CustomContentNodeViewset(ContentNodeViewset):
+    values = (
+        "id",
+        "author",
+        "available",
+        "channel_id",
+        "coach_content",
+        "content_id",
+        "description",
+        "kind",
+        # Language keys
+        "lang__id",
+        "lang__lang_code",
+        "lang__lang_subcode",
+        "lang__lang_name",
+        "lang__lang_direction",
+        "license_description",
+        "license_name",
+        "license_owner",
+        "num_coach_contents",
+        "options",
+        "parent",
+        "sort_order",
+        "title",
+        "lft",
+        "rght",
+        "tree_id",
+    )
+
     def list(self, request, *args, **kwargs):
         queryset = self.filter_queryset(
             self.prefetch_queryset(self.get_queryset())
@@ -35,11 +64,62 @@ class CustomContentNodeViewset(ContentNodeViewset):
             else:
                 tags[t["tagged_content"]].append(t["tag_name"])
 
+        # We need to batch our queries for ancestors as the size of
+        # the expression tree depends on the number of nodes that we
+        # are querying for.  On Windows, the SQL parameter limit is
+        # 999, and an ancestors call can produce 3 parameters per node
+        # in the queryset, so this should max out the parameters at
+        # 750.
+        ANCESTOR_BATCH_SIZE = 250
+
+        if len(items) > ANCESTOR_BATCH_SIZE:
+
+            ancestors_map = {}
+
+            for i in range(0, len(items), ANCESTOR_BATCH_SIZE):
+
+                for anc in (
+                    ContentNode.objects.filter(
+                        id__in=[
+                            item["id"]
+                            for item in items[i : i + ANCESTOR_BATCH_SIZE]
+                        ]
+                    )
+                    .get_ancestors()
+                    .values("id", "title", "lft", "rght", "tree_id")
+                ):
+                    ancestors_map[anc["id"]] = anc
+
+            ancestors = sorted(ancestors_map.values(), key=lambda x: x["lft"])
+        else:
+            ancestors = list(
+                queryset.get_ancestors()
+                .values("id", "title", "lft", "rght", "tree_id")
+                .order_by("lft")
+            )
+
+        def ancestor_lookup(item):
+            lft = item.get("lft")
+            rght = item.get("rght")
+            tree_id = item.get("tree_id")
+            item["ancestors"] = list(
+                map(
+                    lambda x: {"id": x["id"], "title": x["title"]},
+                    filter(
+                        lambda x: x["lft"] < lft
+                        and x["rght"] > rght
+                        and x["tree_id"] == tree_id,
+                        ancestors,
+                    ),
+                )
+            )
+            return item
+
         def add_tag(item):
             item["tags"] = tags.get(item["id"], [])
             return item
 
-        return [add_tag(item) for item in items]
+        return [ancestor_lookup(add_tag(item)) for item in items]
 
     def consolidate(self, items, queryset):
         new_items = super().consolidate(items, queryset)


### PR DESCRIPTION
This is a backport adapted from the current code in the kolibri
development branch at:
https://github.com/learningequality/kolibri/blob/release-v0.15.x/kolibri/core/content/api.py#L393-L439

It adds the ancestors property to all nodes.

Also, make pre-commit hook for flake8 more compatible with
black. Otherwise I can't commit this.

https://phabricator.endlessm.com/T32586