### PR TITLE
template: Remove CSS height rules

### DIFF
--- a/packages/template-ui/src/App.vue
+++ b/packages/template-ui/src/App.vue
@@ -76,15 +76,16 @@ export default {
 html {
   height: 100%;
 }
-/* Always show the vertical scrollbar */
+
 body {
-  overflow-y: scroll;
-  min-height: 100vh;
+  // This is only to prevent a scrollbar to appear for a moment while hashi resizes the iframe:
+  overflow: hidden;
+  height: 100%;
 }
 
 #app {
+  height: 100%;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  min-height: 100vh;
 }
 </style>


### PR DESCRIPTION
Let kolibri hashi take care of the scrolling. Use 100% in all html,
body and #app div to push the footer to the bottom. Avoid vh units
because it doesn't play well with documents inside iframes.

Set overflow hidden in the body because otherwise a scrollbar appears
for a little moment while the hashi resizes the iframe.

https://phabricator.endlessm.com/T32571