### PR TITLE
template: Show number of resources in bundle section

### DIFF
--- a/packages/template-ui/src/views/BundleSection.vue
+++ b/packages/template-ui/src/views/BundleSection.vue
@@ -61,7 +61,12 @@ export default {
   computed: {
     ...mapState(['channel']),
     subtitle() {
-      return utils.getCardSubtitle(this.section, this.channel.name);
+      const bundle = {
+        ...this.section,
+        // Adding section nodes to calculate the number of resources
+        children: this.sectionNodes.nodes,
+      };
+      return utils.getCardSubtitle(bundle, this.channel.name);
     },
   },
   watch: {


### PR DESCRIPTION
This patch adds the sectionNodes to the getCardSubtitle function call to
be able to calculate correctly the number of resources in this section.
This new bundle object emulates the old node object with the hierarchy
tree, so the function calculate the number of resources correctly.

https://phabricator.endlessm.com/T32758