### PR TITLE
discovery: Make AssessmentWrapper to use 100% width

### DIFF
--- a/kolibri_explore_plugin/assets/src/views/ContentModal.vue
+++ b/kolibri_explore_plugin/assets/src/views/ContentModal.vue
@@ -146,4 +146,15 @@
     }
   }
 
+  ::v-deep .modal-content .framework-perseus {
+    padding-bottom: 0;
+  }
+
+  ::v-deep .modal-content .perseus {
+    // Don't show two columns layout on custom modal
+    .pure-u-12-24 {
+      width: 100%;
+    }
+  }
+
 </style>


### PR DESCRIPTION
The content modal doesn't use the full screen width so the styles to
show the tips in a second column is not working correctly even in large
screens.

This patch makes the assesment content to show as 100% width and with
smaller bottom padding.

https://phabricator.endlessm.com/T32786