### PR TITLE
template: Add button to go back in Header

### DIFF
--- a/packages/template-ui/src/components/ChannelHeader.vue
+++ b/packages/template-ui/src/components/ChannelHeader.vue
@@ -3,13 +3,24 @@
     fluid
     :style="{ backgroundImage: (isDescriptionExpanded ? 'none' : headerImageURL) }"
     class="mb-0"
-    :class="{ 'full-height': isDescriptionExpanded, 'has-image': hasHeaderImage }"
+    :class="{ 'full-height': isDescriptionExpanded }"
   >
     <template #default>
       <div class="align-items-start d-flex justify-content-between mt-3">
       </div>
       <b-row>
         <b-col xs="12" sm="8" md="9" lg="9" xl="8">
+          <b-button
+            v-if="true"
+            href="#"
+            pill
+            :variant="hasDarkHeader ? 'dark' : 'light'"
+            size="sm"
+            class="mb-3 pl-0"
+            @click="$router.go(-1)"
+          >
+            <span><ArrowLeft />Back</span>
+          </b-button>
           <h1
             class="d-md-none h3"
             :class="{ 'text-light': hasDarkHeader }"
@@ -38,7 +49,7 @@
                   v-if="expanded || clamped"
                   href="#"
                   pill
-                  :variant="hasHeaderImage ? 'primary' : 'secondary'"
+                  :variant="hasDarkHeader ? 'dark' : 'light'"
                   size="sm"
                   class="my-1"
                   @click.prevent="toggle"
@@ -61,6 +72,7 @@
 <script>
 import { mapState } from 'vuex';
 import VClamp from 'vue-clamp';
+import ArrowLeft from 'vue-material-design-icons/ArrowLeft.vue';
 
 import headerMixin from '@/components/mixins/headerMixin';
 
@@ -68,6 +80,7 @@ export default {
   name: 'ChannelHeader',
   components: {
     VClamp,
+    ArrowLeft,
   },
   mixins: [headerMixin],
   props: {
@@ -111,9 +124,14 @@ export default {
   &.full-height {
     min-height: auto;
   }
-  &.has-image {
-    background-color: $primary;
-  }
+}
+
+$transparent-bg: rgba($gray-700, 0.1);
+
+.btn-light, .btn-dark {
+  background-color: $transparent-bg;
+  border-color: $transparent-bg;
+  outline-color: $transparent-bg;
 }
 
 img {

--- a/packages/template-ui/src/components/mixins/headerMixin.js
+++ b/packages/template-ui/src/components/mixins/headerMixin.js
@@ -27,8 +27,5 @@ export default {
     headerImageURL() {
       return this.sectionImageURL || this.getAssetURL('headerImage');
     },
-    hasHeaderImage() {
-      return this.headerImageURL !== null;
-    },
   },
 };


### PR DESCRIPTION
- Click does the same as going 1 back in window history.
- Style header buttons. This applies to the more/less buttons too.
- Remove conditional for header image in buttons or header background.

https://phabricator.endlessm.com/T32923