### PR TITLE
discovery: Improve going back the custom presentation

### DIFF
--- a/kolibri_explore_plugin/assets/src/modules/topicsTree/index.js
+++ b/kolibri_explore_plugin/assets/src/modules/topicsTree/index.js
@@ -12,6 +12,8 @@ function defaultState() {
     content: {},
     // used to pass parameters to the custom presentation
     customAppParameters: {},
+    // used to go back to the corresponding page from the custom presentation
+    backFromCustomPage: null,
     // used in TOPICS_TOPIC, TOPICS_CHANNEL
     contents: [],
     isRoot: null,
@@ -54,6 +56,9 @@ export default {
     },
     SET_CUSTOM_APP_PARAMETERS(state, payload) {
       state.customAppParameters = payload;
+    },
+    SET_BACK_FROM_CUSTOM_PAGE(state, payload) {
+      state.backFromCustomPage = payload;
     },
   },
 };

--- a/kolibri_explore_plugin/assets/src/routes/index.js
+++ b/kolibri_explore_plugin/assets/src/routes/index.js
@@ -58,8 +58,11 @@ export default [
   {
     name: PageNames.TOPICS_CONTENT,
     path: '/topics/:channel_id/c/:id',
-    handler: toRoute => {
+    handler: (toRoute, fromRoute) => {
       const { channel_id, id } = toRoute.params;
+      if (fromRoute) {
+        store.commit('topicsTree/SET_BACK_FROM_CUSTOM_PAGE', fromRoute.name);
+      }
       store.commit('topicsTree/SET_CUSTOM_APP_PARAMETERS', { contentId: id });
       showTopicsChannel(store, channel_id);
     },

--- a/kolibri_explore_plugin/assets/src/views/CustomChannelPresentationApp.vue
+++ b/kolibri_explore_plugin/assets/src/views/CustomChannelPresentationApp.vue
@@ -44,7 +44,7 @@
         }
         return url;
       },
-      ...mapState('topicsTree', ['channel', 'customAppParameters']),
+      ...mapState('topicsTree', ['backFromCustomPage', 'channel', 'customAppParameters']),
       iframeWindow() {
         return this.$refs.iframe.contentWindow;
       },
@@ -77,7 +77,7 @@
       },
       goToChannelList() {
         this.$router.push({
-          name: PageNames.ROOT,
+          name: this.backFromCustomPage || PageNames.TOPICS_ROOT,
         });
       },
     },


### PR DESCRIPTION
Go back to the corresponding page, not always to the home page as
before.

- vue-router handler: Store the current page in the vuex state before
navigating to the custom presentation.

- Custom channel presentation: Use that state when the event from the
  custom presentation happens to navigate programatically to it.

Also fixes the Navigation cancelled error that happened always when
going back from a custom presentation.

https://phabricator.endlessm.com/T32915