### PR TITLE
discovery: keep the SearchPage state during navigation

### DIFF
--- a/kolibri_explore_plugin/assets/src/components/DiscoveryNavBar.vue
+++ b/kolibri_explore_plugin/assets/src/components/DiscoveryNavBar.vue
@@ -38,6 +38,7 @@
   import ViewDashboardOutlineIcon from 'vue-material-design-icons/ViewDashboardOutline.vue';
   import MagnifyIcon from 'vue-material-design-icons/Magnify.vue';
 
+  import { mapMutations } from 'vuex';
   import { assets } from 'eos-components';
   import { PageNames } from '../constants';
 
@@ -50,15 +51,20 @@
       },
     },
     methods: {
+      ...mapMutations({
+        setSearchResult: 'topicsRoot/SET_SEARCH_RESULT',
+      }),
       goToChannels() {
         this.$router.push({
           name: PageNames.TOPICS_ROOT,
         });
       },
       goToSearch() {
-        this.$router.push({
-          name: PageNames.SEARCH,
-        });
+        // cleaning previous search
+        this.setSearchResult({}),
+          this.$router.push({
+            name: PageNames.SEARCH,
+          });
       },
       currentIsChannels() {
         return this.$route.name === PageNames.TOPICS_ROOT;

--- a/kolibri_explore_plugin/assets/src/views/ExploreIndex.vue
+++ b/kolibri_explore_plugin/assets/src/views/ExploreIndex.vue
@@ -3,12 +3,14 @@
   <div>
     <ContentModal />
     <DevTag v-if="showBuildInfo" />
-    <component
-      :is="currentPage"
-      v-if="currentPage"
-      @loading="onLoading"
-      @load="onLoad"
-    />
+    <keep-alive include="SearchPage">
+      <component
+        :is="currentPage"
+        v-if="currentPage"
+        @loading="onLoading"
+        @load="onLoad"
+      />
+    </keep-alive>
     <b-overlay :show="isLoading" noWrap>
       <template #overlay>
         <img :src="loadingImg">

--- a/kolibri_explore_plugin/assets/src/views/SearchPage.vue
+++ b/kolibri_explore_plugin/assets/src/views/SearchPage.vue
@@ -223,7 +223,6 @@
     },
     mounted() {
       this.query = this.searchTerm || '';
-      this.setSearchResult({});
     },
     methods: {
       ...mapMutations({

--- a/packages/eos-components/src/components/CollapsibleCardGrid.vue
+++ b/packages/eos-components/src/components/CollapsibleCardGrid.vue
@@ -106,8 +106,10 @@ export default {
   },
   watch: {
     nodes() {
-      this.loading = false;
-      this.rowsToShow++;
+      if (this.loading) {
+        this.loading = false;
+        this.rowsToShow++;
+      }
     },
   },
   methods: {


### PR DESCRIPTION
Use the keep-alive wrap in the SearchPage to keep the page state.

https://phabricator.endlessm.com/T32940