### PR TITLE
force 'lft' ordering in custom API

### DIFF
--- a/kolibri_explore_plugin/assets/src/kolibriApi.js
+++ b/kolibri_explore_plugin/assets/src/kolibriApi.js
@@ -53,6 +53,7 @@ class KolibriApi {
         kind: kind,
         kind_in: kinds,
         descendant_of: options.descendantOf,
+        ordering: 'lft',
       },
     }).then(contentNodes => {
       const { more, results } = contentNodes;


### PR DESCRIPTION
https://phabricator.endlessm.com/T32889

This is a second solution to the ordering problem with the new API. If LE doesn't accept the simple default ordering change we can try to propose this one: https://github.com/endlessm/kolibri/pull/22/files