### PR TITLE
Discovery: Reset search input on Search tab select

### DIFF
--- a/kolibri_explore_plugin/assets/src/components/DiscoveryNavBar.vue
+++ b/kolibri_explore_plugin/assets/src/components/DiscoveryNavBar.vue
@@ -53,6 +53,7 @@
     methods: {
       ...mapMutations({
         setSearchResult: 'topicsRoot/SET_SEARCH_RESULT',
+        setSearchTerm: 'SET_SEARCH_TERM',
       }),
       goToChannels() {
         this.$router.push({
@@ -62,6 +63,7 @@
       goToSearch() {
         // cleaning previous search
         this.setSearchResult({}),
+          this.setSearchTerm(''),
           this.$router.push({
             name: PageNames.SEARCH,
           });

--- a/kolibri_explore_plugin/assets/src/routes/index.js
+++ b/kolibri_explore_plugin/assets/src/routes/index.js
@@ -18,7 +18,9 @@ export default [
     name: PageNames.SEARCH,
     path: '/search/:query?',
     handler: toRoute => {
-      store.commit('SET_SEARCH_TERM', toRoute.params.query);
+      if (toRoute.params.query) {
+        store.commit('SET_SEARCH_TERM', toRoute.params.query);
+      }
       store.commit('SET_PAGE_NAME', PageNames.SEARCH);
     },
   },

--- a/kolibri_explore_plugin/assets/src/views/SearchPage.vue
+++ b/kolibri_explore_plugin/assets/src/views/SearchPage.vue
@@ -227,13 +227,17 @@
       cleanedQuery() {
         this.search(this.cleanedQuery);
       },
-    },
-    mounted() {
-      this.query = this.searchTerm || '';
+      searchTerm() {
+        this.query = this.searchTerm || '';
+      },
+      query() {
+        this.setSearchTerm(this.query);
+      },
     },
     methods: {
       ...mapMutations({
         setSearchResult: 'topicsRoot/SET_SEARCH_RESULT',
+        setSearchTerm: 'SET_SEARCH_TERM',
       }),
       goBack() {
         this.$router.push({


### PR DESCRIPTION
The query attribute was not reset when showing the SearchPage, this
patch sync the query attribute in  the SearchPage with the searchTerm in
the store, and it's set to empty on clicking in the tab.

The searchTerm is not updated with the URL if the query parameter is not
passed as part of the url, so it's keeped when navigating to content and
back.

https://phabricator.endlessm.com/T32988