### PR TITLE
Discovery: Disable search input during search

### DIFF
--- a/kolibri_explore_plugin/assets/src/views/SearchPage.vue
+++ b/kolibri_explore_plugin/assets/src/views/SearchPage.vue
@@ -8,6 +8,7 @@
         v-model="query"
         :debounce="800"
         :progress="progress"
+        :loading="isLoading"
         @clear-input="clearInput"
       />
       <b-container class="pb-5 pt-3">
@@ -225,13 +226,11 @@
     },
     watch: {
       cleanedQuery() {
+        this.setSearchTerm(this.query);
         this.search(this.cleanedQuery);
       },
       searchTerm() {
         this.query = this.searchTerm || '';
-      },
-      query() {
-        this.setSearchTerm(this.query);
       },
     },
     methods: {

--- a/packages/eos-components/src/components/SearchBar.vue
+++ b/packages/eos-components/src/components/SearchBar.vue
@@ -4,8 +4,7 @@
       <b-input-group>
         <template #prepend>
           <b-input-group-text>
-            <b-spinner v-if="loading" small label="Spinning" />
-            <MagnifyIcon v-else />
+            <MagnifyIcon />
           </b-input-group-text>
         </template>
         <template #append>
@@ -67,6 +66,13 @@
         default: 100,
       },
     },
+    watch: {
+      loading() {
+        this.$nextTick(() => {
+          this.focusSearchInput();
+        });
+      },
+    },
     created() {
       this.updateValue = _.debounce(this.inputUpdated, this.debounce);
     },
@@ -99,6 +105,10 @@
     background-color: transparent;
     border: none;
     box-shadow: none;
+  }
+  &:disabled {
+    background-color: $white;
+    color: $text-muted;
   }
   font-size: $h5-font-size;
 }


### PR DESCRIPTION
This patch disables the SearchBar input during the loading to avoid
edit the query during a search so the text input is disabled until the
API query is completely done.

After the search the input grab the focus again, so it's easy to change
the query without clicking anywhere.

https://phabricator.endlessm.com/T32917