### PR TITLE
template: Replace route when receiving params

### DIFF
--- a/packages/template-ui/src/App.vue
+++ b/packages/template-ui/src/App.vue
@@ -64,17 +64,17 @@ export default {
       }
       const contentId = params.get('contentId');
       if (contentId) {
-        this.$router.push(`/c/${contentId}`);
+        this.$router.replace(`/c/${contentId}`);
         return;
       }
       const topicId = params.get('topicId');
       if (topicId) {
-        this.$router.push(`/t/${topicId}`);
+        this.$router.replace(`/t/${topicId}`);
         return;
       }
       const test = params.get('test');
       if (test === 'true') {
-        this.$router.push('/test');
+        this.$router.replace('/test');
       }
     },
   },


### PR DESCRIPTION
In App we do a bit of routing when receiving parameters, to go to
either a specific content, topic, or the test page.

We shouldn't account this as two navigations in the browser
history. Use router replace instead of router push to do it.

https://phabricator.endlessm.com/T33012