### PR TITLE
template: Create channel override for wikihow

### DIFF
--- a/kolibri_explore_plugin/assets/src/customApps.js
+++ b/kolibri_explore_plugin/assets/src/customApps.js
@@ -30,6 +30,7 @@ export const CustomChannelApps = {
   '2f95235c3709511fa12d007f31ed6a7b': 'steam',
   bf0260ed911f44cda27a263db93a8512: '49ers-edu-digital-playbook',
   '9c33eb395508447d96c96682cb18c57a': 'techbridge-girls-home',
+  '35ec8e78266d545b9449af6e2409b10d': 'wikihow',
 };
 
 export function getAppNameByID(id) {

--- a/packages/template-ui/channel-overrides/wikihow/components/Breadcrumb.vue
+++ b/packages/template-ui/channel-overrides/wikihow/components/Breadcrumb.vue
@@ -1,0 +1,40 @@
+<template>
+  <b-navbar-nav
+    class="mt-3"
+    aria-label="breadcrumb"
+  >
+    <b-link
+      class="d-none d-sm-block mt-2"
+      to="/"
+    >
+      <ChannelLogo :channel="channel" size="sm" />
+    </b-link>
+    <ol
+      class="bg-transparent breadcrumb flex-nowrap px-2"
+    >
+      <li
+        v-b-tooltip.hover
+        :title="channel.name"
+        class="breadcrumb-item text-light text-truncate"
+      >
+        <b-link to="/">
+          {{ channel.name }}
+        </b-link>
+      </li>
+    </ol>
+  </b-navbar-nav>
+</template>
+
+<script>
+import { responsiveMixin } from 'eos-components';
+import { mapState } from 'vuex';
+
+
+export default {
+  name: 'Breadcrumb',
+  mixins: [responsiveMixin],
+  computed: {
+    ...mapState(['channel']),
+  },
+};
+</script>

--- a/packages/template-ui/channel-overrides/wikihow/components/DetailView.vue
+++ b/packages/template-ui/channel-overrides/wikihow/components/DetailView.vue
@@ -1,0 +1,44 @@
+<template>
+  <iframe
+    ref="iframe"
+    class="content-iframe"
+    scrolling="no"
+    frameBorder="0"
+    :src="rooturl"
+  >
+  </iframe>
+</template>
+
+<script>
+export default {
+  name: 'DetailView',
+  props: {
+    node: {
+      type: Object,
+      required: true,
+    },
+  },
+  computed: {
+    rooturl() {
+      if (!this.node) {
+        return '';
+      }
+      return `/explore/#/content/${this.node.id}`;
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+@import '@/styles.scss';
+
+$main-container-top: $navbar-height;
+
+.content-iframe {
+  position: fixed;
+  top: $main-container-top;
+  width: 100%;
+  height: 100vh;
+}
+
+</style>

--- a/packages/template-ui/channel-overrides/wikihow/options.json
+++ b/packages/template-ui/channel-overrides/wikihow/options.json
@@ -1,0 +1,11 @@
+{
+  "displayLogoInHeader": true,
+  "hasSectionsSearch": false,
+  "hasCarousel": false,
+  "hasFilters": false,
+  "defaultContentNode": "523579b884485b3295ede0a9c2a7062f",
+  "isEndlessApp": true,
+  "bundleKind": "simple",
+  "showFooter": false,
+  "showNextContent": false
+}

--- a/packages/template-ui/channel-overrides/wikihow/styles.scss
+++ b/packages/template-ui/channel-overrides/wikihow/styles.scss
@@ -1,0 +1,2 @@
+$header-color: $light;
+$app-body-overflow: hidden;


### PR DESCRIPTION
The custom presentation for wikihow is similar to what we've right now
for wikipedia, just an override of the Breadcrumb and the DetailView to
show the defaultContentNode fullscreen.

https://phabricator.endlessm.com/T33008