### PR TITLE
template: Move defaultContentNode logic to a NavigationGuard

### DIFF
--- a/packages/template-ui/src/router/index.js
+++ b/packages/template-ui/src/router/index.js
@@ -6,6 +6,8 @@ import Section from '@/views/Section.vue';
 import Content from '@/views/Content.vue';
 import Test from '@/views/Test.vue';
 
+import store from '@/store';
+
 Vue.use(VueRouter);
 
 const routes = [
@@ -18,6 +20,18 @@ const routes = [
     path: '/',
     name: 'Home',
     component: Home,
+    beforeEnter: (to, from, next) => {
+      const { defaultContentNode } = store.state;
+      if (defaultContentNode) {
+        next({
+          name: 'Content',
+          params: { contentId: defaultContentNode },
+          replace: true,
+        });
+      } else {
+        next();
+      }
+    }
   },
   {
     path: '/search',

--- a/packages/template-ui/src/views/Home.vue
+++ b/packages/template-ui/src/views/Home.vue
@@ -61,7 +61,7 @@
 
 <script>
 import { mapState, mapGetters } from 'vuex';
-import { constants, utils } from 'eos-components';
+import { constants } from 'eos-components';
 
 const sectionPageSize = 2 * constants.ItemsPerSlide;
 
@@ -88,7 +88,6 @@ export default {
       'hasCarousel',
       'hasFilters',
       'hasFlatGrid',
-      'defaultContentNode',
     ]),
     ...mapGetters({
       getAssetURL: 'getAssetURL',
@@ -108,11 +107,7 @@ export default {
       this.fetchCarouselNodes(),
       this.fetchContentNodes(),
       this.fetchSectionNodes(),
-    ]).then(() => {
-      if (this.defaultContentNode) {
-        this.showDefaultContent();
-      }
-    });
+    ]);
   },
   methods: {
     fetchCarouselNodes() {
@@ -202,24 +197,6 @@ export default {
           pagination: pageResult.more,
         };
       });
-    },
-    goToContent(node) {
-      const url = utils.getNodeUrl(node);
-      this.$router.push(url);
-    },
-    showDefaultContent() {
-      const { nodes } = this.contentNodes;
-      const contentNodes = nodes.filter(n => n.id === this.defaultContentNode);
-      let [node] = contentNodes;
-
-      if (contentNodes.length === 0 && nodes.length === 1) {
-        [node] = nodes;
-      }
-
-      if (node) {
-        // Showing the first node
-        this.goToContent(node);
-      }
     },
   },
 };


### PR DESCRIPTION
Instead doing the redirection in the component, this patch does the
redirection using a vue-router NavigationGuard so this is done before
loading the Home component.

With this change the ability of loading the first ContentNode setting
the defaultContentNode to true is lost, but it's not a big issue for the
Endless Key.

https://phabricator.endlessm.com/T33009