### PR TITLE
Set defaultContentNode for each WikiHow channel

### DIFF
--- a/packages/template-ui/channel-overrides/wikihow-arts-and-entertainment/options.json
+++ b/packages/template-ui/channel-overrides/wikihow-arts-and-entertainment/options.json
@@ -3,7 +3,7 @@
   "hasSectionsSearch": false,
   "hasCarousel": false,
   "hasFilters": false,
-  "defaultContentNode": "523579b884485b3295ede0a9c2a7062f",
+  "defaultContentNode": "42ddd4230da75a968737261c86c98375",
   "isEndlessApp": true,
   "bundleKind": "simple",
   "showFooter": false,

--- a/packages/template-ui/channel-overrides/wikihow-computers-and-electronics/options.json
+++ b/packages/template-ui/channel-overrides/wikihow-computers-and-electronics/options.json
@@ -3,7 +3,7 @@
   "hasSectionsSearch": false,
   "hasCarousel": false,
   "hasFilters": false,
-  "defaultContentNode": "523579b884485b3295ede0a9c2a7062f",
+  "defaultContentNode": "567ff365c1505df2a6cae9da90576dd7",
   "isEndlessApp": true,
   "bundleKind": "simple",
   "showFooter": false,

--- a/packages/template-ui/channel-overrides/wikihow-hobbies-and-crafts/options.json
+++ b/packages/template-ui/channel-overrides/wikihow-hobbies-and-crafts/options.json
@@ -3,7 +3,7 @@
   "hasSectionsSearch": false,
   "hasCarousel": false,
   "hasFilters": false,
-  "defaultContentNode": "523579b884485b3295ede0a9c2a7062f",
+  "defaultContentNode": "8ea79b1f836956399234630731ecd48b",
   "isEndlessApp": true,
   "bundleKind": "simple",
   "showFooter": false,


### PR DESCRIPTION
This change changes each WikiHow category channel to show the
corresponding default node. It fixes an error in #343 where the default
content node was set to the same value as the full WikiHow channel.

https://phabricator.endlessm.com/T33008