### PR TITLE
scripts: Add script to ingest highlighted content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ apps-bundle.zip
 
 # Symlink to template overrides
 packages/template-ui/src/overrides
+
+# Environment file with secrets
+/.env

--- a/README.md
+++ b/README.md
@@ -134,6 +134,23 @@ pre-commit install -f --install-hooks
 There is a continuous integration tool that will run the same checks
 per pull request.
 
+### Ingesting highlighted content
+
+Make sure to have a `.env` file with the spreadsheet key as content:
+
+```
+CONTENT_SPREADSHEET_KEY=123456
+```
+
+Then run the script:
+
+```
+./scripts/ingest_highlighted.py
+```
+
+If everything goes well, the `highlighted-content.json` file will be
+updated. You then need to commit the file.
+
 ### Making a release
 
 If you are releasing a new version, first please bump to either major,

--- a/scripts/_common.py
+++ b/scripts/_common.py
@@ -27,6 +27,10 @@ DEFAULT_OVERRIDE_PATH = os.path.join(CHANNEL_OVERRIDES_DIR, DEFAULT_OVERRIDE)
 
 DEFAULT_ZIP_NAME = "custom-channel-ui"
 
+HIGHLIGHTED_CONTENT_PATH = os.path.join(
+    PROJECT_DIR, "kolibri_explore_plugin", "static", "highlighted-content.json"
+)
+
 
 def bundle_zip(zip_name):
     shutil.make_archive(zip_name, "zip", "dist/")

--- a/scripts/ingest_highlighted.py
+++ b/scripts/ingest_highlighted.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+import csv
+import json
+import os
+from binascii import Error as BinasciiError
+from binascii import unhexlify
+from enum import IntEnum
+
+import requests
+from _common import HIGHLIGHTED_CONTENT_PATH
+
+
+URL_TEMPLATE = (
+    "https://docs.google.com/spreadsheets/d/{key}/"
+    + "gviz/tq?tqx=out:csv&sheet={sheet}&range={range}"
+)
+URL_PARAMS = {
+    "key": os.getenv("CONTENT_SPREADSHEET_KEY") or "XXX_MISSING_KEY",
+    "sheet": "HIGHLIGHTS",
+    "range": "A:B",
+}
+
+
+# Spreadsheet columns:
+class Columns(IntEnum):
+    TITLE = 0
+    ID = 1
+
+
+def get_rows_from_sheet():
+    """Helper function to extract the data from the spreadsheet"""
+    url = URL_TEMPLATE.format(**URL_PARAMS)
+    response = requests.get(url)
+    response.raise_for_status()
+
+    def strip_row_text(row):
+        return row[Columns.TITLE].strip(), row[Columns.ID].strip()
+
+    csv_iterator = csv.reader(response.text.splitlines())
+    return map(strip_row_text, csv_iterator)
+
+
+def parse_set(rows_iterator):
+    """Parse IDs until a row has the '----' delimiter."""
+    ids = []
+    for row in rows_iterator:
+        if row[Columns.TITLE].startswith("----"):
+            return ids
+        # Ignore invalid IDs:
+        if is_valid_id(row[Columns.ID]):
+            ids.append(row[Columns.ID])
+    return ids
+
+
+def is_valid_id(node_id_string):
+    """True if the ID is hexadecimal and with corresponding length."""
+    try:
+        node_id_binary = unhexlify(node_id_string)
+        return len(node_id_binary) == 16
+    except BinasciiError:
+        print(f"Invalid node ID: {node_id_string}")
+        return False
+
+
+def parse_and_validate_channel_id(rows_iterator):
+    """Parse next row assumming it's a channel set header.
+
+    If the ID does not validate, stop parsing.  The channel IDs are
+    the only ones that must be valide.  Other IDs will be ignored.
+    """
+    channel_id = next(rows_iterator)[Columns.ID]
+    if not is_valid_id(channel_id):
+        raise Exception("Invalid channel ID.")
+    return channel_id
+
+
+def parse_rows(rows_iterator):
+    output = {
+        # Special key for highlighted content in the Discovery page.
+        # The other keys are channel IDs.
+        "DISCOVERY": [],
+    }
+
+    # Skip first line, it's the table header:
+    next(rows_iterator)
+
+    # Parse highlighted content for Discovery:
+    output["DISCOVERY"] = parse_set(rows_iterator)
+
+    # Parse highlighted content per channel:
+    while True:
+        try:
+            channel_id = parse_and_validate_channel_id(rows_iterator)
+            output[channel_id] = parse_set(rows_iterator)
+        except StopIteration:
+            break
+    return output
+
+
+rows_iterator = get_rows_from_sheet()
+output = parse_rows(rows_iterator)
+
+# ## For debugging:
+# from pprint import pprint
+# pprint(output)
+
+with open(HIGHLIGHTED_CONTENT_PATH, "w") as output_file:
+    json.dump(output, output_file)


### PR DESCRIPTION
Add a script that:
- Reads a spreadsheet sheet
- Parses the rows, and
- writes a JSON file.

The sheet has sets of rows. The first set is content to be highlighted
in the Discovery page. The other sets must start with a channel ID,
and it's one set per channel.

The data in the JSON will be used later for filling the carousels with
content with a rotation logic.

Invalid IDs are ignored, except for the channel IDs. If a channel ID
is invalid, we raise an exception to stop execution.

Read spreadsheet key from a local, uncommited `.env` file. Pipenv
handles this automatically. Explain in the README. And add the file to
the list ignored by GIT.

https://phabricator.endlessm.com/T33016