### PR TITLE
template: Keep the search state

### DIFF
--- a/packages/template-ui/src/App.vue
+++ b/packages/template-ui/src/App.vue
@@ -3,7 +3,7 @@
     <BackToTop />
     <!-- Wrapper needed to fix flexbox footer positioning on IE11 -->
     <div class="flex-fill flex-shrink-0">
-      <keep-alive include="Search">
+      <keep-alive include="Search,Home">
         <router-view />
       </keep-alive>
     </div>

--- a/packages/template-ui/src/App.vue
+++ b/packages/template-ui/src/App.vue
@@ -3,7 +3,9 @@
     <BackToTop />
     <!-- Wrapper needed to fix flexbox footer positioning on IE11 -->
     <div class="flex-fill flex-shrink-0">
-      <router-view />
+      <keep-alive include="Search">
+        <router-view />
+      </keep-alive>
     </div>
     <ChannelFooter v-if="showFooter" />
   </div>

--- a/packages/template-ui/src/router/index.js
+++ b/packages/template-ui/src/router/index.js
@@ -37,6 +37,13 @@ const routes = [
     path: '/search',
     name: 'Search',
     component: Search,
+    beforeEnter(to, from, next) {
+      if (from.name === 'Home') {
+        // Clean the search query when coming from home
+        store.commit('setSearchQuery', '');
+      }
+      next();
+    },
   },
   {
     path: '/t/:topicId',

--- a/packages/template-ui/src/store/index.js
+++ b/packages/template-ui/src/store/index.js
@@ -19,6 +19,7 @@ const initialState = {
   // Channel and nodes, as they come from kolibri:
   channel: {},
   mainSections: [],
+  searchQuery: '',
 
   isStandaloneChannel: false,
 
@@ -67,6 +68,9 @@ const store = new Vuex.Store({
     },
     setIsStandaloneChannel(state) {
       state.isStandaloneChannel = true;
+    },
+    setSearchQuery(state, payload) {
+      state.searchQuery = payload;
     },
   },
   getters: {

--- a/packages/template-ui/src/views/Search.vue
+++ b/packages/template-ui/src/views/Search.vue
@@ -64,7 +64,7 @@ export default {
   },
   computed: {
     ...mapGetters(['getAssetURL']),
-    ...mapState(['mainSections', 'cardColumns', 'mediaQuality']),
+    ...mapState(['mainSections', 'cardColumns', 'mediaQuality', 'searchQuery']),
     backgroundImageURL() {
       return this.getAssetURL('homeBackgroundImage');
     },
@@ -87,6 +87,7 @@ export default {
   },
   watch: {
     cleanedQuery() {
+      this.$store.commit('setSearchQuery', this.cleanedQuery);
       if (this.cleanedQuery === '') {
         this.searching = false;
         this.resultNodes = [];
@@ -95,6 +96,9 @@ export default {
       }
       this.searching = true;
       this.search();
+    },
+    searchQuery() {
+      this.query = this.searchQuery;
     },
   },
   methods: {


### PR DESCRIPTION
Keep alive the Search component to do not loose the search after
clicking on a card and going back.

This patch also introduces a new navigation guard to the Search route so
the search is clean when the from route is the Home. That way the search
is clean when the user clicks in the Search Keywords link.

https://phabricator.endlessm.com/T33025