### PR TITLE
Update defaultContentNode for Wikipedia

### DIFF
--- a/packages/template-ui/channel-overrides/wikipedia/options.json
+++ b/packages/template-ui/channel-overrides/wikipedia/options.json
@@ -3,7 +3,7 @@
   "hasSectionsSearch": false,
   "hasCarousel": false,
   "hasFilters": false,
-  "defaultContentNode": "98731f06729457ed9b6ffe154a0a78c4",
+  "defaultContentNode": "ddd7dac476255acd8adffdac28502b49",
   "showDetailViewFullScreen": true,
   "showParentsInBreadcrumb": false,
   "isEndlessApp": true,


### PR DESCRIPTION
This was incorrectly set to the node ID for "100 Wikipedia Articles".
Instead, we should use the "Selected Wikipedia Articles" node.

https://phabricator.endlessm.com/T33053