### PR TITLE
Increase search debounce time and trigger with Enter

### DIFF
--- a/kolibri_explore_plugin/assets/src/views/SearchPage.vue
+++ b/kolibri_explore_plugin/assets/src/views/SearchPage.vue
@@ -12,7 +12,7 @@
       <SearchBar
         v-model="query"
         class="search-row"
-        :debounce="800"
+        :debounce="2000"
         :progress="progress"
         :loading="isLoading"
         @clear-input="clearInput"

--- a/kolibri_explore_plugin/assets/src/views/SearchPage.vue
+++ b/kolibri_explore_plugin/assets/src/views/SearchPage.vue
@@ -12,7 +12,6 @@
       <SearchBar
         v-model="query"
         class="search-row"
-        :debounce="2000"
         :progress="progress"
         :loading="isLoading"
         @clear-input="clearInput"

--- a/packages/eos-components/src/components/SearchBar.vue
+++ b/packages/eos-components/src/components/SearchBar.vue
@@ -42,6 +42,7 @@
   import _ from 'underscore';
   import CloseIcon from 'vue-material-design-icons/CloseCircleOutline.vue';
   import MagnifyIcon from 'vue-material-design-icons/Magnify.vue';
+  import { SearchBarDebounce } from '../constants.js';
 
   export default {
     name: 'SearchBar',
@@ -56,7 +57,7 @@
       },
       debounce: {
         type: Number,
-        default: 500,
+        default: SearchBarDebounce,
       },
       loading: {
         type: Boolean,

--- a/packages/eos-components/src/components/SearchBar.vue
+++ b/packages/eos-components/src/components/SearchBar.vue
@@ -23,6 +23,7 @@
           placeholder="Type keywords to search"
           :disabled="loading"
           :value="value"
+          @keyup.enter="inputUpdated($event.target.value)"
           @input="updateValue($event.target.value)"
         >
       </b-input-group>

--- a/packages/eos-components/src/constants.js
+++ b/packages/eos-components/src/constants.js
@@ -52,6 +52,7 @@ export const ItemsPerSlide = 4;
 export const ItemsPerPage = 16;
 
 export const KeywordIconSize = 20;
+export const SearchBarDebounce = 2000;
 
 export default {
   AuthorFilterName,
@@ -65,6 +66,7 @@ export default {
   MediaFilterName,
   MediaQuality,
   MediaTypeVerbs,
+  SearchBarDebounce,
   StructuredTags,
   StructuredTagsRegExp,
   TagFilterName,

--- a/packages/template-ui/src/views/Search.vue
+++ b/packages/template-ui/src/views/Search.vue
@@ -4,7 +4,11 @@
     :style="{ backgroundImage: backgroundImageURL }"
   >
     <ChannelNavBar />
-    <SearchBar v-model="query" @clear-input="onClearInput" />
+    <SearchBar
+      v-model="query"
+      :debounce="2000"
+      @clear-input="onClearInput"
+    />
 
     <EmptyResultsMessage v-if="notFound" :showTopics="false">
       <h1 class="text-secondary">

--- a/packages/template-ui/src/views/Search.vue
+++ b/packages/template-ui/src/views/Search.vue
@@ -6,7 +6,6 @@
     <ChannelNavBar />
     <SearchBar
       v-model="query"
-      :debounce="2000"
       @clear-input="onClearInput"
     />
 


### PR DESCRIPTION
Increase the debounce time to 2 seconds and capture the Enter key event
to trigger the search when it happens.

https://phabricator.endlessm.com/T33126