### PR TITLE
discovery: Use 3 cards per slide in categorized channels

### DIFF
--- a/kolibri_explore_plugin/assets/src/components/CategorizedChannelsList.vue
+++ b/kolibri_explore_plugin/assets/src/components/CategorizedChannelsList.vue
@@ -16,6 +16,9 @@
           v-slot="slotProps"
           :nodes="channels"
           :hasWhiteBackground="true"
+          :itemsPerSlideLarge="3"
+          :itemsPerSlideMedium="2"
+          :itemsPerSlideSmall="1"
         >
           <ChannelCard
             v-for="channel in slotProps.slideNodes"

--- a/packages/eos-components/src/components/SlidableGrid.vue
+++ b/packages/eos-components/src/components/SlidableGrid.vue
@@ -77,6 +77,18 @@ export default {
       type: Boolean,
       default: false,
     },
+    itemsPerSlideSmall: {
+      type: Number,
+      default: Math.ceil(ItemsPerSlide / 4),
+    },
+    itemsPerSlideMedium: {
+      type: Number,
+      default: Math.ceil(ItemsPerSlide / 2),
+    },
+    itemsPerSlideLarge: {
+      type: Number,
+      default: Math.ceil(ItemsPerSlide),
+    },
   },
   data() {
     return {
@@ -87,12 +99,12 @@ export default {
   computed: {
     itemsPerSlide() {
       if (this.xs) {
-        return Math.ceil(ItemsPerSlide / 4);
+        return this.itemsPerSlideSmall;
       }
       if (this.sm || this.md) {
-        return Math.ceil(ItemsPerSlide / 2);
+        return this.itemsPerSlideMedium;
       }
-      return Math.ceil(ItemsPerSlide);
+      return this.itemsPerSlideLarge;
     },
     slides() {
       return _.chunk(this.nodes, this.itemsPerSlide);


### PR DESCRIPTION
Make the number of cards inside the slidable grid configurable. And
match the number of columns in the ChannelCardGroup:
- use 3 cards per slide for normal/large screens
- 2 for medium/small screens
- 1 for very small screens

https://phabricator.endlessm.com/T33092