### PR TITLE
template: Do not modify filter state object inplace

### DIFF
--- a/packages/template-ui/src/components/FilterResult.vue
+++ b/packages/template-ui/src/components/FilterResult.vue
@@ -71,9 +71,8 @@
               if (!params.tags) {
                 params.tags = [];
               }
-              options.forEach((option) => {
-                params.tags.push(`${matchKey}=${option}`);
-              });
+              const structuredTags = options.map((option) => `${matchKey}=${option}`);
+              params.tags = [...params.tags, ...structuredTags];
             }
           });
         }


### PR DESCRIPTION
This patch makes a copy of the common keywords filter query when
modifying to avoid to modify the object in place. The new array is used
for the query to the API but the state shouldn't be modified.

https://phabricator.endlessm.com/T33128