### PR TITLE
CI: Set @vue/cli version to v4.5.15

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install pre-commit
         pre-commit install -f --install-hooks
-        yarn global add @vue/cli
+        yarn global add @vue/cli@v4.5.15
         yarn install
 
     - name: Lint

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -21,7 +21,7 @@ jobs:
         node-version: '10.24.1'
     - name: Install dependencies
       run: |
-        yarn global add @vue/cli
+        yarn global add @vue/cli@v4.5.15
         yarn install
 
     - name: Build

--- a/.github/workflows/release-apps.yml
+++ b/.github/workflows/release-apps.yml
@@ -20,7 +20,7 @@ jobs:
         node-version: '10.24.1'
     - name: Install dependencies
       run: |
-        yarn global add @vue/cli
+        yarn global add @vue/cli@v4.5.15
         yarn install
 
     - name: Build

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -5,5 +5,5 @@
 pipenv install
 pipenv run nodeenv -p --node=10.24.1
 pipenv run npm install -g yarn@1.22.10
-pipenv run yarn global add @vue/cli
+pipenv run yarn global add @vue/cli@v4.5.15
 pipenv run yarn install


### PR DESCRIPTION
This fixes the issue with the last release of @vue/cli

error open@8.4.0: The engine "node" is incompatible with this module.
Expected version ">=12". Got "10.24.1"

https://phabricator.endlessm.com/T33182