### PR TITLE
Discovery: Scroll to top when clicking the Search tab

### DIFF
--- a/kolibri_explore_plugin/assets/src/components/DiscoveryNavBar.vue
+++ b/kolibri_explore_plugin/assets/src/components/DiscoveryNavBar.vue
@@ -61,12 +61,15 @@
         });
       },
       goToSearch() {
-        // cleaning previous search
-        this.setSearchResult({}),
-          this.setSearchTerm(''),
-          this.$router.push({
-            name: PageNames.SEARCH,
-          });
+        // Cleaning previous search:
+        this.setSearchResult({});
+        this.setSearchTerm('');
+        // Scroll to top. For some reason this is not needed when going to channels:
+        window.scrollTo({ top: 0 });
+        // Then go:
+        this.$router.push({
+          name: PageNames.SEARCH,
+        });
       },
       currentIsChannels() {
         return this.$route.name === PageNames.TOPICS_ROOT;


### PR DESCRIPTION
This is not needed when clicking on the Channels tab because that view
always refreshes it's content.

Also, fix the Javascript in the method which had commas instead of
semicolons.

https://phabricator.endlessm.com/T33179