### PR TITLE
Discovery: Drop search results from previous queries

### DIFF
--- a/kolibri_explore_plugin/assets/src/components/DiscoveryNavBar.vue
+++ b/kolibri_explore_plugin/assets/src/components/DiscoveryNavBar.vue
@@ -52,7 +52,6 @@
     },
     methods: {
       ...mapMutations({
-        setSearchResult: 'topicsRoot/SET_SEARCH_RESULT',
         setSearchTerm: 'SET_SEARCH_TERM',
       }),
       goToChannels() {
@@ -61,8 +60,6 @@
         });
       },
       goToSearch() {
-        // Cleaning previous search:
-        this.setSearchResult({});
         this.setSearchTerm('');
         // Scroll to top. For some reason this is not needed when going to channels:
         window.scrollTo({ top: 0 });

--- a/kolibri_explore_plugin/assets/src/modules/topicsRoot/handlers.js
+++ b/kolibri_explore_plugin/assets/src/modules/topicsRoot/handlers.js
@@ -197,7 +197,7 @@ export function searchChannels(store, search, kind) {
       channel: rootNodes.find(c => c.id === n.channel_id),
     }));
     const promises = channel_ids.map(id => ChannelResource.fetchModel({ id }));
-    Promise.all(promises).then(collection => {
+    return Promise.all(promises).then(collection => {
       const channels = collection
         .map(c => ({
           ...c,
@@ -206,15 +206,9 @@ export function searchChannels(store, search, kind) {
           order: channel_ids.indexOf(c.id),
         }))
         .sort((a, b) => a.order - b.order);
-      store.commit('topicsRoot/SET_SEARCH_RESULT', {
-        ...store.state.topicsRoot.searchResult,
-        [kind]: {
-          ...searchResults,
-          channels: channels,
-          results: nodes,
-        },
-      });
+
       store.commit('CORE_SET_PAGE_LOADING', false);
+      return { kind, channels, nodes };
     });
   });
 }

--- a/kolibri_explore_plugin/assets/src/modules/topicsRoot/index.js
+++ b/kolibri_explore_plugin/assets/src/modules/topicsRoot/index.js
@@ -2,7 +2,6 @@ export default {
   namespaced: true,
   state: {
     rootNodes: [],
-    searchResult: {},
     carouselNodes: [],
   },
   mutations: {
@@ -11,9 +10,6 @@ export default {
     },
     RESET_STATE(state) {
       state.rootNodes = [];
-    },
-    SET_SEARCH_RESULT(state, payload) {
-      state.searchResult = payload;
     },
     SET_CAROUSEL_NODES(state, payload) {
       state.carouselNodes = payload;


### PR DESCRIPTION
This patch adds a new optional parameter to the searchChannels function
to be able to drop search results for old searches.

The SearchPage component increments the searchQueryIndex for every
search, so if there's a race condition and a search query done before
ends after a second search query has been launched, it will be dropped
because the searchQueryIndex returned will be different from the one
specified in the new search query.

https://phabricator.endlessm.com/T33202