### PR TITLE
components: Focus SearchBar on activated

### DIFF
--- a/packages/eos-components/src/components/SearchBar.vue
+++ b/packages/eos-components/src/components/SearchBar.vue
@@ -83,6 +83,11 @@
         this.focusSearchInput();
       });
     },
+    activated() {
+      this.$nextTick(() => {
+        this.focusSearchInput();
+      });
+    },
     methods: {
       inputUpdated(value) {
         this.$emit('input', value);


### PR DESCRIPTION
This component is used in keep-alive parent components, so the mounted
lifecycle hook will be triggered only once. Instead, use the activated
lifecycle hook which works with keep-alive, as the documentation says:

https://vuejs.org/api/options-lifecycle.html#activated

https://phabricator.endlessm.com/T33199