### PR TITLE
discovery: Ignore previous search promises

### DIFF
--- a/kolibri_explore_plugin/assets/src/modules/topicsRoot/index.js
+++ b/kolibri_explore_plugin/assets/src/modules/topicsRoot/index.js
@@ -4,6 +4,7 @@ export default {
     rootNodes: [],
     searchResult: {},
     carouselNodes: [],
+    lastSearchPromises: {},
   },
   mutations: {
     SET_STATE(state, payload) {
@@ -17,6 +18,12 @@ export default {
     },
     SET_CAROUSEL_NODES(state, payload) {
       state.carouselNodes = payload;
+    },
+    SET_LAST_SEARCH_PROMISE(state, payload) {
+      state.lastSearchPromises[payload.kind] = payload.searchPromise;
+    },
+    RESET_LAST_SEARCH_PROMISES(state) {
+      state.lastSearchPromises = {};
     },
   },
 };

--- a/kolibri_explore_plugin/assets/src/views/SearchPage.vue
+++ b/kolibri_explore_plugin/assets/src/views/SearchPage.vue
@@ -110,7 +110,7 @@
   import { getContentNodeThumbnail } from 'kolibri.utils.contentNode';
 
   import { PageNames } from '../constants';
-  import { searchChannels } from '../modules/topicsRoot/handlers';
+  import { searchChannelsOnce } from '../modules/topicsRoot/handlers';
 
   import AlphabeticalChannelsList from '../components/AlphabeticalChannelsList';
   import DiscoveryNavBar from '../components/DiscoveryNavBar';
@@ -234,6 +234,11 @@
     created() {
       this.query = this.searchTerm || '';
     },
+    deactivated() {
+      // Clear progress and ignore any incoming search promises:
+      this.progress = 0;
+      this.$store.commit('topicsRoot/RESET_LAST_SEARCH_PROMISES');
+    },
     methods: {
       ...mapMutations({
         setSearchResult: 'topicsRoot/SET_SEARCH_RESULT',
@@ -259,7 +264,7 @@
 
         this.progress = 0;
         kinds.forEach(k => {
-          searchChannels(this.$store, query, k).then(() => {
+          searchChannelsOnce(this.$store, query, k).then(() => {
             this.resultKinds.push(k);
             this.progress += 100 / kinds.length;
           });


### PR DESCRIPTION
By keeping track of the last promise per each kind, we are able to
ignore the previous ones by not resolving them.

This fixes issues with old promises provoking inconsistent or
duplicate results coming from a previous search.

This is done in a new `searchLastChannels()` method which wraps
`searchChannels()` so it can be easily replaced.

Also, clear the progress bar and mark all promises as "old" when the
component is deactivated.

https://phabricator.endlessm.com/T33202