### PR TITLE
discovery: Fix extraFields in ContentItem

### DIFF
--- a/kolibri_explore_plugin/assets/src/views/ContentItem.vue
+++ b/kolibri_explore_plugin/assets/src/views/ContentItem.vue
@@ -119,7 +119,7 @@
           files: this.contentNode.files,
           options: this.contentNode.options,
           available: this.contentNode.available,
-          extraFields: this.extraFields,
+          extraFields: this.extra_fields,
           progress: this.progress,
           userId: this.currentUserId,
           userFullName: this.fullName,


### PR DESCRIPTION
This patch fix the variable name in the ContentItem to load correctly
the extraFields of a content node.

https://phabricator.endlessm.com/T33233