### PR TITLE
Auto authenticate

### DIFF
--- a/kolibri_explore_plugin/assets/src/views/ContentItem.vue
+++ b/kolibri_explore_plugin/assets/src/views/ContentItem.vue
@@ -119,7 +119,7 @@
           files: this.contentNode.files,
           options: this.contentNode.options,
           available: this.contentNode.available,
-          extraFields: this.extraFields,
+          extraFields: this.extra_fields,
           progress: this.progress,
           userId: this.currentUserId,
           userFullName: this.fullName,

--- a/kolibri_explore_plugin/middleware.py
+++ b/kolibri_explore_plugin/middleware.py
@@ -1,0 +1,25 @@
+from django.conf import settings
+from django.contrib.auth import login
+from kolibri.core.auth.models import Facility
+from kolibri.core.auth.models import FacilityUser
+
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    MiddlewareMixin = object
+
+
+class AlwaysAuthenticatedMiddleware(MiddlewareMixin):
+    def __init__(self, *args, **kwargs):
+
+        self.username = "endless"
+        super(AlwaysAuthenticatedMiddleware, self).__init__(*args, **kwargs)
+
+    def process_request(self, request):
+        if not request.user.is_authenticated():
+            facility = Facility.get_default_facility()
+            user, created = FacilityUser.objects.get_or_create(
+                username=self.username, facility=facility
+            )
+            user.backend = settings.AUTHENTICATION_BACKENDS[0]
+            login(request, user)

--- a/kolibri_explore_plugin/settings.py
+++ b/kolibri_explore_plugin/settings.py
@@ -1,0 +1,6 @@
+from kolibri.deployment.default.settings.base import *  # noqa @UnusedWildImport
+
+
+MIDDLEWARE = list(MIDDLEWARE) + [  # noqa F405
+    "kolibri_explore_plugin.middleware.AlwaysAuthenticatedMiddleware"
+]


### PR DESCRIPTION
This PR just adds a middleware and a custom settings file to extend the Kolibri default settings, so this new settings can be used in custom deployments like the Endless Key to auto authenticate the users with:

```
DJANGO_SETTINGS_MODULE = "kolibri_explore_plugin.middleware.AlwaysAuthenticatedMiddleware"
```

This is built on top of this PR: https://github.com/endlessm/kolibri-explore-plugin/pull/401

https://phabricator.endlessm.com/T33233