### PR TITLE
Filter out *.map files in custom channel bundles

### DIFF
--- a/scripts/_common.py
+++ b/scripts/_common.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 import os
-import shutil
 import subprocess
+import zipfile
+from pathlib import Path
 
 
 PROJECT_DIR = subprocess.check_output(
@@ -31,10 +32,21 @@ HIGHLIGHTED_CONTENT_PATH = os.path.join(
     PROJECT_DIR, "kolibri_explore_plugin", "static", "highlighted-content.json"
 )
 
+BUNDLE_EXCLUDE_GLOBS = ["*.map"]
 
-def bundle_zip(zip_name):
-    shutil.make_archive(zip_name, "zip", "dist/")
-    print(f"File ./{zip_name}.zip created.")
+
+def bundle_zip(zip_name, compression=zipfile.ZIP_LZMA):
+    root_path = Path("dist")
+
+    if not zip_name.endswith(".zip"):
+        zip_name = zip_name + ".zip"
+
+    with zipfile.ZipFile(zip_name, "w", compression=compression) as bundle:
+        for path in root_path.glob("**/*"):
+            if not any(path.match(glob) for glob in BUNDLE_EXCLUDE_GLOBS):
+                bundle.write(path, path.relative_to(root_path))
+
+    print(f"File ./{zip_name} created.")
 
 
 def get_available_overrides():


### PR DESCRIPTION
To support this, we need to use the zipfile module directly to create
each channel's zip file. In addition, we can use ZIP_LZMA compression
for improved performance. Lzma is supported in Python 3.3 and later.

https://phabricator.endlessm.com/T33430