### PR TITLE
InstallContent: Requeue stalled jobs

### DIFF
--- a/kolibri_explore_plugin/assets/src/components/InstallContentModal.vue
+++ b/kolibri_explore_plugin/assets/src/components/InstallContentModal.vue
@@ -170,6 +170,7 @@
             showChannels(this.$store);
             this.downloading = false;
           } else {
+            this.downloading = true;
             if (completed !== this.channelsDownloaded) {
               this.channelsDownloaded = completed;
               ChannelResource.clearCache();

--- a/kolibri_explore_plugin/assets/src/views/ExploreIndex.vue
+++ b/kolibri_explore_plugin/assets/src/views/ExploreIndex.vue
@@ -2,7 +2,9 @@
 
   <div>
     <BackToTop />
-    <InstallContentModal />
+    <keep-alive>
+      <InstallContentModal />
+    </keep-alive>
     <ContentModal />
     <AboutModal id="about-modal" />
     <DevTag v-if="showBuildInfo" />


### PR DESCRIPTION
This patch adds the process ID to the tasks created to import the
channels and requeue this tasks if the process ID is different from the
previous one.

This way the stalled jobs will start again if the application is closed
during a content installation.

The task type is also changed to "REMOTEIMPORT", to show these tasks in
the Kolibri device plugin.

https://phabricator.endlessm.com/T33482