### PR TITLE
loading: Remove back button from EndlessKey view when required

### DIFF
--- a/packages/loading-screen/src/App.vue
+++ b/packages/loading-screen/src/App.vue
@@ -38,7 +38,7 @@ export default {
     }
 
     window.show_endless_key = () => {
-      this.$router.push('/endless-key');
+      this.$router.push('/endless-key-required');
     }
 
     window.setHasUSB = () => {

--- a/packages/loading-screen/src/main.js
+++ b/packages/loading-screen/src/main.js
@@ -18,6 +18,11 @@ const routes = [
   { path: '/loading/:state', component: Loading },
   { path: '/welcome', component: Welcome },
   { path: '/endless-key', component: EndlessKey },
+  {
+    path: '/endless-key-required',
+    component: EndlessKey,
+    props: { required: true },
+  },
 ];
 
 const router = new VueRouter({

--- a/packages/loading-screen/src/views/EndlessKey.vue
+++ b/packages/loading-screen/src/views/EndlessKey.vue
@@ -18,6 +18,7 @@
 
       <div class="buttons mt-5">
         <b-button
+          v-if="!required"
           class="mx-4"
           variant="link"
           @click="goBack"
@@ -30,7 +31,7 @@
           :disabled="!hasUSB"
           @click="loadWithUSB"
         >
-          Load my content
+          {{ nextButtonText }}
         </b-button>
       </div>
     </div>
@@ -43,10 +44,25 @@
 
   export default {
     name: 'EndlessKey',
+    props: {
+      required: {
+        type: Boolean,
+        default: false,
+      },
+    },
     data() {
       return {
         hasUSB: false,
       };
+    },
+    computed: {
+      nextButtonText() {
+        if (this.required) {
+          return 'Next';
+        }
+
+        return 'Load my content';
+      },
     },
     mounted() {
       window.setHasUSB = (hasUSB) => {


### PR DESCRIPTION
This patch adds a new path to show the EndlessKey view without the back
button for the returning users that has the database created with the
USB content and the USB is not connected. The USB should be required and
there's no possibility to go back to the welcome page.

https://phabricator.endlessm.com/T33569