### PR TITLE
Fix the size units

### DIFF
--- a/kolibri_explore_plugin/views.py
+++ b/kolibri_explore_plugin/views.py
@@ -114,7 +114,7 @@ class AppMetadataView(AppBase):
 class EndlessLearningCollection(View):
     COLLECTIONS = {
         "small": {
-            "title": "3Gb",
+            "title": "3 GB",
             "subtitle": "Small",
             "channels": 10,
             "size": 3,
@@ -123,7 +123,7 @@ class EndlessLearningCollection(View):
             "available": True,
         },
         "medium": {
-            "title": "6Gb",
+            "title": "6 GB",
             "subtitle": "Medium",
             "channels": 10,
             "size": 6,
@@ -132,7 +132,7 @@ class EndlessLearningCollection(View):
             "available": True,
         },
         "large": {
-            "title": "12Gb",
+            "title": "12 GB",
             "subtitle": "Large",
             "channels": 10,
             "size": 12,

--- a/packages/eos-components/src/components/CollectionSelectionModal.vue
+++ b/packages/eos-components/src/components/CollectionSelectionModal.vue
@@ -36,7 +36,7 @@
               variant="primary"
               :disabled="!collection.available"
             >
-              Download <strong>{{ collection.size }}Gb</strong>
+              Download <strong>{{ collection.size }} GB</strong>
             </b-button>
           </WelcomeCard>
         </b-card-group>
@@ -72,7 +72,7 @@
         default: () => {
           return [
             {
-              title: '3Gb',
+              title: '3 GB',
               subtitle: 'Small',
               channels: 10,
               text: 'Short Description to be defined',


### PR DESCRIPTION
The download size unit should be xx bytes. The bytes can be simplified
as capitalized 'B'. The lowercase 'b' represents bit.

https://phabricator.endlessm.com/T33685