### PR TITLE
Welcome screen: Better state management

### DIFF
--- a/packages/loading-screen/src/App.vue
+++ b/packages/loading-screen/src/App.vue
@@ -8,6 +8,7 @@
 </template>
 
 <script>
+import { store } from "./store.js";
 
 export default {
   name: 'App',
@@ -53,9 +54,12 @@ export default {
       this.$router.push('/permissions-wrong-folder');
     }
 
-    window.setHasUSB = () => {
-      // Does nothing.
-      // This function is implemented in the UsbDriveConnection view component
+    window.setHasUSB = (isUsbConnected) => {
+      store.setUsbConnected(isUsbConnected);
+    }
+
+    window.setNeedsPermission = (needsPermission) => {
+      store.setNeedsPermission(needsPermission);
     }
 
     window.firstLaunch = () => {

--- a/packages/loading-screen/src/main.js
+++ b/packages/loading-screen/src/main.js
@@ -11,6 +11,7 @@ import PermissionsCancelled from '@/views/PermissionsCancelled.vue';
 import PermissionsWrongFolder from '@/views/PermissionsWrongFolder.vue';
 import Loading from '@/views/Loading.vue';
 import Welcome from '@/views/Welcome.vue';
+import { store } from "@/store.js";
 
 Vue.use(BootstrapVue);
 Vue.use(IconsPlugin);
@@ -41,5 +42,6 @@ const router = new VueRouter({
 
 window.app = new Vue({
   router,
+  data: store.state,
   render: (h) => h(App),
 }).$mount('#app');

--- a/packages/loading-screen/src/store.js
+++ b/packages/loading-screen/src/store.js
@@ -1,0 +1,12 @@
+export const store = {
+  state: {
+    isUsbConnected: false,
+    needsPermission: false,
+  },
+  setUsbConnected (isUsbConnected) {
+    this.state.isUsbConnected = isUsbConnected;
+  },
+  setNeedsPermission (needsPermission) {
+    this.state.needsPermission = needsPermission;
+  },
+};

--- a/packages/loading-screen/src/views/UsbDriveConnection.vue
+++ b/packages/loading-screen/src/views/UsbDriveConnection.vue
@@ -37,6 +37,7 @@
 <script>
   import usbBackgroundConnect from '../assets/usb-connect.jpg';
   import usbBackgroundConnected from '../assets/usb-connected.jpg';
+  import { store } from "../store.js";
 
   export default {
     name: 'UsbDriveConnection',
@@ -46,34 +47,19 @@
         default: false,
       },
     },
-    data() {
-      return {
-        hasUSB: false,
-        needsPermission: false,
-      };
-    },
     computed: {
+      hasUSB() {
+        return store.state.isUsbConnected;
+      },
+      needsPermission() {
+        return store.state.needsPermission;
+      },
       usbBackground() {
         if (this.hasUSB) {
           return usbBackgroundConnected;
         }
         return usbBackgroundConnect;
       },
-    },
-    mounted() {
-      window.setHasUSB = (hasUSB) => {
-        this.hasUSB = hasUSB;
-      };
-      window.setNeedsPermission = (needsPermission) => {
-        this.needsPermission = needsPermission;
-      };
-    },
-    beforeDestroy() {
-      function fallback() {
-        console.log('No loading screen');
-      };
-      window.setHasUSB = fallback;
-      window.needsPermission = fallback;
     },
     methods: {
       loadWithUSB() {


### PR DESCRIPTION
By implementing a simple store without vuex. This removes the
need to override setters in the components. Now the host app
(Android/Windows) can still call APIs like:
`window.setHasUSB(true)` and this is reactive to all the
welcome screen, not just a single component.