### PR TITLE
Release loading-screen ZIP file

### DIFF
--- a/.github/workflows/release-apps.yml
+++ b/.github/workflows/release-apps.yml
@@ -33,4 +33,6 @@ jobs:
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        files: apps-bundle.zip
+        files: |
+          apps-bundle.zip
+          packages/loading-screen/loading-screen.zip

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ build/
 dist/
 kolibri_explore_plugin.egg-info/
 packages/*/custom-channel-ui.zip
+packages/loading-screen/loading-screen.zip
 packages/template-ui/src/nodes.json
 packages/template-ui/*.zip
 apps-bundle.zip

--- a/packages/loading-screen/package.json
+++ b/packages/loading-screen/package.json
@@ -4,8 +4,9 @@
   "license": "AGPL-3.0",
   "scripts": {
     "serve": "vue-cli-service serve",
-    "build": "../../scripts/set_override.py default && vue-cli-service build",
-    "lint": "vue-cli-service lint"
+    "build": "../../scripts/set_override.py default && vue-cli-service build && yarn zip",
+    "lint": "vue-cli-service lint",
+    "zip": "../../scripts/bundle_zip.py loading-screen.zip"
   },
   "dependencies": {
     "bootstrap": "^4.6.1",

--- a/scripts/bundle_bundles.py
+++ b/scripts/bundle_bundles.py
@@ -11,7 +11,7 @@ from _common import get_available_overrides
 from _common import TEMPLATE_WORKSPACE
 
 DEFAULT_ZIP_FILENAME = "custom-channel-ui.zip"
-SKIP_WORKSPACES = ["kolibri-api", TEMPLATE_WORKSPACE]
+SKIP_WORKSPACES = ["kolibri-api", "loading-screen", TEMPLATE_WORKSPACE]
 
 
 def validate_dir_path(path):


### PR DESCRIPTION
Pulling the loading-screen JS package out of the python package is cumbersome, so also release it as a ZIP file.