### PR TITLE
Content packs view: Fix setting loadingNodes

### DIFF
--- a/kolibri_explore_plugin/assets/src/views/DiscoveryPageContenPacks.vue
+++ b/kolibri_explore_plugin/assets/src/views/DiscoveryPageContenPacks.vue
@@ -3,7 +3,7 @@
   <div class="channels-page d-flex flex-column min-vh-100">
     <DiscoveryNavBar />
 
-    <template v-if="loading && loadingNodes">
+    <template v-if="loading || loadingNodes">
       <CardGridPlaceholder />
     </template>
     <template v-else>
@@ -95,7 +95,6 @@
                 .map(utils.addStructuredTag)
                 .map(utils.updateExploreNodeUrl);
               this.sectionNodes[tag] = nodes;
-              this.loadingNodes = false;
             });
           })
         ).then(() => {


### PR DESCRIPTION
This was a leftover line inside the map function. The loadingNodes variable should be set to false after all the collections are fetched. As it's already happening in the then() clause.

https://phabricator.endlessm.com/T34521