### PR TITLE
Packs backend: Consider complete state for resume

### DIFF
--- a/kolibri_explore_plugin/collectionviews.py
+++ b/kolibri_explore_plugin/collectionviews.py
@@ -600,8 +600,12 @@ def get_should_resume(request):
     if saved_state is not None:
         grade = saved_state["grade"]
         name = saved_state["name"]
+    should_resume = (
+        saved_state is not None
+        and saved_state["stage"] != DownloadStage.COMPLETED.name
+    )
     return Response(
-        {"shouldResume": saved_state is not None, "grade": grade, "name": name}
+        {"shouldResume": should_resume, "grade": grade, "name": name}
     )
 
 


### PR DESCRIPTION
This fixes "starter pack has been delivered" message appearing again on each Kolibri startup.

https://phabricator.endlessm.com/T34525