### PR TITLE
Theme: Use light variant on buttons hover

### DIFF
--- a/packages/eos-components/src/index.scss
+++ b/packages/eos-components/src/index.scss
@@ -36,8 +36,18 @@
 
 // Change buttons variant:
 @each $color, $value in $theme-colors {
-  .btn-#{$color}-primary {
+  .btn-#{$color} {
     $hover-value: scale-color($value, $lightness: $hover-lightness);
+    @include button-variant(
+      $background: $value,
+      $border: $value,
+      $hover-background: $hover-value,
+      $active-background: $hover-value,
+      $active-border: $hover-value);
+  }
+
+  .btn-#{$color}-primary {
+    $hover-value: scale-color($value, $lightness: $hover-primary-lightness);
     @include button-variant(
       $background: $value,
       $border: $value,

--- a/packages/eos-components/src/styles.scss
+++ b/packages/eos-components/src/styles.scss
@@ -97,7 +97,8 @@ $breadcrumb-bg: $secondary !default;
 // Template variables:
 $header-logo-width: 128;
 $header-height: 349px; // Forms an area with the LG breakpoint of aspect ratio: 2.8444
-$hover-lightness: 25%;
+$hover-lightness: 7.5%;
+$hover-primary-lightness: 25%;
 $background-alpha: -8%;
 $card-image-ar: calc(9 / 16);
 


### PR DESCRIPTION
By default the bootstrap theme has 7,5% darken of the normal color. That doesn't work for our current primary color because it's black. So change it to 7.5% lighten.

https://phabricator.endlessm.com/T34616