### PR TITLE
ContentPage: Fix ContentPage's contentNode

### DIFF
--- a/kolibri_explore_plugin/assets/src/views/ContentPage.vue
+++ b/kolibri_explore_plugin/assets/src/views/ContentPage.vue
@@ -1,7 +1,7 @@
 <template>
 
   <div v-if="content">
-    <ContentItem isDark expand :content="content" />
+    <ContentItem isDark expand :contentNode="content" />
   </div>
 
 </template>


### PR DESCRIPTION
The commit 3c84d23a9e02 ("ContentItem: Adapt to upstream changes") did the corresponding modification for migration kolibri to 16 alpha. Following that, the ContentItem's "content" should be replaced by "ContentNode".

https://phabricator.endlessm.com/T34817