### PR TITLE
Add 'About' footer to search page and Iguana landing page

### DIFF
--- a/kolibri_explore_plugin/assets/src/components/AboutFooter.vue
+++ b/kolibri_explore_plugin/assets/src/components/AboutFooter.vue
@@ -1,0 +1,43 @@
+<template>
+
+  <b-container class="mb-5">
+
+    <b-row class="d-flex justify-content-center" cols="3">
+
+      <b-col class="col-auto d-flex justify-content-center">
+        <button
+          v-b-modal.about-modal
+          class="btn d-md-block d-none shadow-none"
+        >
+          {{ $tr('aboutLabel') }}
+        </button>
+      </b-col>
+
+      <b-col class="col-auto d-flex justify-content-center">
+        <button
+          v-b-modal.about-modal
+          class="btn d-md-block d-none shadow-none"
+          @click="$root.$emit('setAboutSection', 'privacy-policy-link')"
+        >
+          {{ $tr('privacyPolicyLabel') }}
+        </button>
+      </b-col>
+
+    </b-row>
+
+  </b-container>
+
+</template>
+
+
+<script>
+
+  export default {
+    name: 'AboutFooter',
+    $trs: {
+      aboutLabel: 'About Endless Key',
+      privacyPolicyLabel: 'Privacy Policy',
+    },
+  };
+
+</script>

--- a/kolibri_explore_plugin/assets/src/views/DiscoveryPageContenPacks.vue
+++ b/kolibri_explore_plugin/assets/src/views/DiscoveryPageContenPacks.vue
@@ -69,27 +69,9 @@
             :nodes="sectionNodes['curious']"
           />
         </template>
-        <b-container class="mb-5">
-          <b-row class="d-flex justify-content-center" cols="3">
-            <b-col class="col-auto d-flex justify-content-center">
-              <button
-                v-b-modal.about-modal
-                class="btn d-md-block d-none shadow-none"
-              >
-                {{ $tr('aboutLabel') }}
-              </button>
-            </b-col>
-            <b-col class="col-auto d-flex justify-content-center">
-              <button
-                v-b-modal.about-modal
-                class="btn d-md-block d-none shadow-none"
-                @click="$root.$emit('setAboutSection', 'privacy-policy-link')"
-              >
-                {{ $tr('privacyPolicyLabel') }}
-              </button>
-            </b-col>
-          </b-row>
-        </b-container>
+
+        <AboutFooter />
+
       </b-container>
     </template>
 
@@ -105,13 +87,14 @@
 
   import { utils, constants } from 'ek-components';
   import DiscoveryNavBar from '../components/DiscoveryNavBar';
+  import AboutFooter from '../components/AboutFooter';
   import { ContentNodeExtrasResource } from '../apiResources';
   import navigationMixin from '../mixins/navigationMixin';
   import { getBigThumbnail, getChannelIcon } from '../customApps';
 
   export default {
     name: 'DiscoveryPageContenPacks',
-    components: { DiscoveryNavBar },
+    components: { DiscoveryNavBar, AboutFooter },
     mixins: [commonCoreStrings, navigationMixin],
     data() {
       return {
@@ -165,8 +148,6 @@
       channelLabel: 'Your channels',
       careerLabel: 'Explore careers',
       curiousLabel: 'Feeling curious?',
-      aboutLabel: 'About Endless Key',
-      privacyPolicyLabel: 'Privacy Policy',
     },
   };
 

--- a/kolibri_explore_plugin/assets/src/views/DiscoveryPageEkIguana.vue
+++ b/kolibri_explore_plugin/assets/src/views/DiscoveryPageEkIguana.vue
@@ -36,6 +36,8 @@
 
     </div>
 
+    <AboutFooter class="pt-3" />
+
   </div>
 
 </template>
@@ -49,10 +51,11 @@
 
   import EkIguanaList from '../components/EkIguanaList';
   import DiscoveryNavBar from '../components/DiscoveryNavBar';
+  import AboutFooter from '../components/AboutFooter';
 
   export default {
     name: 'DiscoveryPageEkIguana',
-    components: { EkIguanaList, DiscoveryNavBar },
+    components: { EkIguanaList, DiscoveryNavBar, AboutFooter },
     mixins: [commonCoreStrings],
     props: {},
     computed: {

--- a/kolibri_explore_plugin/assets/src/views/SearchPage.vue
+++ b/kolibri_explore_plugin/assets/src/views/SearchPage.vue
@@ -95,6 +95,8 @@
 
       </template>
 
+      <AboutFooter />
+
     </div>
 
   </div>
@@ -113,6 +115,7 @@
 
   import AlphabeticalChannelsList from '../components/AlphabeticalChannelsList';
   import DiscoveryNavBar from '../components/DiscoveryNavBar';
+  import AboutFooter from '../components/AboutFooter';
 
   const kinds = Object.keys(constants.MediaTypeVerbs);
 
@@ -123,7 +126,7 @@
         title: this.$tr('documentTitle'),
       };
     },
-    components: { AlphabeticalChannelsList, DiscoveryNavBar },
+    components: { AlphabeticalChannelsList, DiscoveryNavBar, AboutFooter },
     mixins: [navigationMixin, responsiveMixin],
     data() {
       return {


### PR DESCRIPTION
When these links were moved from the navigation bar to the footer of the landing page, we forgot to also add them to the search page and landing page used by the physical USB. This commit adds them there.

https://phabricator.endlessm.com/T34665