### PR TITLE
Fix and simplify EkCardBody

### DIFF
--- a/packages/ek-components/src/components/EkCardBody.vue
+++ b/packages/ek-components/src/components/EkCardBody.vue
@@ -1,48 +1,40 @@
 <template>
   <div class="card-content">
-    <v-container>
 
-      <!-- Channel -->
-      <v-row v-if="showChannelIcon">
-        <v-col>
-          <!-- FIXME only for debugging: -->
-          <span class="debug-node-id sr-only">{{ node.id }}</span>
-          <div class="align-items-center d-flex mb-3">
-            <EkChannelLogo class="mr-2" :channel="node.channel" size="sm" />
-            <span class="channel-title text-muted text-truncate">{{ node.channel.title }}</span>
-          </div>
-        </v-col>
-      </v-row>
+    <!-- FIXME only for debugging: -->
+    <span class="debug-node-id sr-only">{{ node.id }}</span>
 
-      <!-- Title -->
-      <v-row>
-        <v-col>
-          <h5 class="align-items-center mb-1 title">
-            <VClamp
-              autoresize
-              :maxLines="titleLines"
-            >
-              {{ node.title }}
-            </VClamp>
-          </h5>
-        </v-col>
-      </v-row>
+    <!-- Channel -->
+    <div v-if="showChannelIcon">
+      <div class="align-items-center d-flex mb-3">
+        <EkChannelLogo class="mr-2" :channel="node.channel" size="sm" />
+        <span class="channel-title text-muted text-truncate">{{ node.channel.title }}</span>
+      </div>
+    </div>
 
-      <!-- Description -->
-      <v-row v-if="!showChannelIcon">
-        <v-col>
-          <p class="mb-1 subtitle text-muted">
-            <VClamp
-              autoresize
-              :maxLines="3"
-            >
-              {{ subtitle }}
-            </VClamp>
-          </p>
-        </v-col>
-      </v-row>
+    <!-- Title -->
+    <div>
+      <h5 class="align-items-center mb-1 title">
+        <VClamp
+          autoresize
+          :maxLines="titleLines"
+        >
+          {{ node.title }}
+        </VClamp>
+      </h5>
+    </div>
 
-    </v-container>
+    <!-- Description -->
+    <div v-if="!showChannelIcon">
+      <p class="mb-1 subtitle text-muted">
+        <VClamp
+          autoresize
+          :maxLines="3"
+        >
+          {{ subtitle }}
+        </VClamp>
+      </p>
+    </div>
 
   </div>
 </template>
@@ -83,9 +75,6 @@ export default {
 .card-content {
   // FIXME this is aproximate, the function has regressed:
   height: card-body-height(2);
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
 }
 
 .channel-title {
@@ -95,7 +84,6 @@ export default {
 }
 
 .subtitle {
-  flex-grow: 3;
   line-height: 1.1;
 }
 </style>


### PR DESCRIPTION
Remove unused/unknown elements. Simplify to use divs and remove any flex CSS that is not actually needed.

Issue #534