### PR TITLE
Add Download button to channels

### DIFF
--- a/kolibri_explore_plugin/assets/src/kolibriApi.js
+++ b/kolibri_explore_plugin/assets/src/kolibriApi.js
@@ -202,6 +202,16 @@ class KolibriApi {
       };
     });
   }
+
+  downloadChannel() {
+    // TODO: this is a temporary workaround to the lack of
+    // channel downloads. It merely redirects to the Devices
+    // page.
+    const deviceContentUrl = urls['kolibri:kolibri.plugins.device:device_management'];
+    if (deviceContentUrl) {
+      window.open(`${deviceContentUrl()}#/content`, '_self');
+    }
+  }
 }
 
 const kolibriApi = new KolibriApi();

--- a/packages/template-ui/src/components/SectionsSearchRow.vue
+++ b/packages/template-ui/src/components/SectionsSearchRow.vue
@@ -19,7 +19,12 @@
 
       <!-- Download button -->
       <b-col v-if="showDownloadButton" md="auto">
-        <b-button pill class="font-weight-bold text-nowrap" variant="outline-dark">
+        <b-button
+          pill
+          class="font-weight-bold text-nowrap"
+          variant="outline-dark"
+          @click="downloadChannel()"
+        >
           <CloudDownloadOutlineIcon :size="iconSize" class="mr-1" />
           Download full channel
         </b-button>
@@ -45,6 +50,11 @@ export default {
     },
     showDownloadButton() {
       return !this.channel.available;
+    },
+  },
+  methods: {
+    downloadChannel() {
+      window.kolibri.downloadChannel();
     },
   },
 };

--- a/packages/template-ui/src/components/SectionsSearchRow.vue
+++ b/packages/template-ui/src/components/SectionsSearchRow.vue
@@ -17,20 +17,34 @@
         </MainSections>
       </b-col>
 
+      <!-- Download button -->
+      <b-col v-if="showDownloadButton" md="auto">
+        <b-button pill class="font-weight-bold text-nowrap" variant="outline-dark">
+          <CloudDownloadOutlineIcon :size="iconSize" class="mr-1" />
+          Download full channel
+        </b-button>
+      </b-col>
+
     </b-row>
   </b-container>
 </template>
 
 <script>
+import CloudDownloadOutlineIcon from 'vue-material-design-icons/CloudDownloadOutline.vue';
 import MagnifyIcon from 'vue-material-design-icons/Magnify.vue';
 import { constants } from 'ek-components';
+import { mapState } from 'vuex';
 
 export default {
   name: 'SectionsSearchRow',
-  components: { MagnifyIcon },
+  components: { CloudDownloadOutlineIcon, MagnifyIcon },
   computed: {
+    ...mapState(['channel']),
     iconSize() {
       return constants.KeywordIconSize;
+    },
+    showDownloadButton() {
+      return !this.channel.available;
     },
   },
 };

--- a/packages/template-ui/src/components/SectionsSearchRow.vue
+++ b/packages/template-ui/src/components/SectionsSearchRow.vue
@@ -1,16 +1,23 @@
 <template>
   <b-container class="my-4">
-    <MainSections>
-      <b-button
-        class="font-weight-bold my-1 text-nowrap"
-        size="sm"
-        variant="link"
-        to="/search"
-      >
-        <MagnifyIcon :size="iconSize" class="mr-1" />
-        Search Keywords
-      </b-button>
-    </MainSections>
+    <b-row>
+
+      <!-- Section buttons -->
+      <b-col>
+        <MainSections>
+          <b-button
+            class="font-weight-bold my-1 text-nowrap"
+            size="sm"
+            variant="link"
+            to="/search"
+          >
+            <MagnifyIcon :size="iconSize" class="mr-1" />
+            Search Keywords
+          </b-button>
+        </MainSections>
+      </b-col>
+
+    </b-row>
   </b-container>
 </template>
 


### PR DESCRIPTION
The button is a stub, it merely redirects to the devices tab, and just redirects to the Devices tab, but I think it at least is visible / hidden correctly.

https://github.com/endlessm/kolibri-explore-plugin/issues/532