### PR TITLE
Search page: Add switch to control showing unavailable content

### DIFF
--- a/kolibri_explore_plugin/assets/src/modules/topicsRoot/handlers.js
+++ b/kolibri_explore_plugin/assets/src/modules/topicsRoot/handlers.js
@@ -237,13 +237,13 @@ export function showChannels(store) {
     });
 }
 
-export function searchChannelsOnce(store, search, kind) {
+export function searchChannelsOnce(store, search, kind, includeUnavailable) {
   const searchPromise = ContentNodeSearchResource.fetchCollection({
     getParams: {
       search,
       kind,
       max_results: SEARCH_MAX_RESULTS,
-      ...(NO_AVAILABLE_FILTERING && { no_available_filtering: true }),
+      ...(includeUnavailable && { no_available_filtering: true }),
     },
   });
   store.commit('topicsRoot/SET_LAST_SEARCH_PROMISE', { kind, searchPromise });

--- a/kolibri_explore_plugin/assets/src/views/SearchPage.vue
+++ b/kolibri_explore_plugin/assets/src/views/SearchPage.vue
@@ -109,6 +109,7 @@
   import _ from 'lodash';
   import { mapMutations, mapState } from 'vuex';
   import { utils, constants, responsiveMixin } from 'ek-components';
+  import plugin_data from 'plugin_data';
 
   import { searchChannelsOnce } from '../modules/topicsRoot/handlers';
   import navigationMixin from '../mixins/navigationMixin';
@@ -139,6 +140,7 @@
         mediaQuality: constants.MediaQuality.REGULAR,
         progress: 100,
         resultKinds: [],
+        showUnavailable: plugin_data.navigateUnavailable,
       };
     },
     computed: {
@@ -251,7 +253,7 @@
 
         this.progress = 0;
         kinds.forEach(k => {
-          searchChannelsOnce(this.$store, query, k).then(() => {
+          searchChannelsOnce(this.$store, query, k, this.showUnavailable).then(() => {
             this.resultKinds.push(k);
             this.progress += 100 / kinds.length;
           });

--- a/kolibri_explore_plugin/assets/src/views/SearchPage.vue
+++ b/kolibri_explore_plugin/assets/src/views/SearchPage.vue
@@ -21,7 +21,16 @@
 
       <template v-else>
         <b-container>
-          <EkKeywords :words="keywords" @click="removeKeyword" />
+          <b-row alignH="between">
+            <b-col>
+              <b-form-checkbox v-model="showUnavailable" name="check-show-unavailable" switch>
+                {{ $tr('showUnavailableLabel') }}
+              </b-form-checkbox>
+            </b-col>
+            <b-col class="text-right">
+              <EkKeywords :words="keywords" @click="removeKeyword" />
+            </b-col>
+          </b-row>
         </b-container>
 
         <template v-if="resultCards">
@@ -230,6 +239,10 @@
       searchTerm() {
         this.query = this.searchTerm || '';
       },
+      showUnavailable() {
+        this.setSearchTerm(this.query);
+        this.search(this.cleanedQuery);
+      },
     },
     created() {
       this.query = this.searchTerm || '';
@@ -273,6 +286,7 @@
     },
     $trs: {
       documentTitle: 'Library',
+      showUnavailableLabel: 'Show unavailable content',
     },
   };
 


### PR DESCRIPTION
This adds a switch to the search results page that controls whether the
results should include content that is not available on the device
(i.e., needs to be downloaded).

Fixes: https://github.com/endlessm/kolibri-explore-plugin/issues/572