### PR TITLE
CI: Generate release note automatically

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,5 @@
+changelog:
+  categories:
+    - title: Changes
+      labels:
+        - "*"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/') || startsWith(inputs.tagname, 'v')
         with:
+          generate_release_notes: true
           files: |
             apps-bundle.zip
             packages/welcome-screen/welcome-screen.zip


### PR DESCRIPTION
Make softprops/action-gh-release action generates the release note along with releasing. The release note follows the format of the ducoment "Automatically generated release notes" [1]

[1]: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes

Fixes: https://github.com/endlessm/kolibri-explore-plugin/issues/577