### PR TITLE
Download backend: Request all thumbnails for channel

### DIFF
--- a/kolibri_explore_plugin/__init__.py
+++ b/kolibri_explore_plugin/__init__.py
@@ -1,1 +1,3 @@
 __version__ = "6.16.0"
+
+default_app_config = "kolibri_explore_plugin.apps_config.ExploreConfig"

--- a/kolibri_explore_plugin/apps_config.py
+++ b/kolibri_explore_plugin/apps_config.py
@@ -1,0 +1,11 @@
+from django.apps import AppConfig
+
+
+class ExploreConfig(AppConfig):
+    name = "kolibri_explore_plugin"
+    label = "explore"
+
+    def ready(self):
+        from .tasks import restart_failed_background_jobs
+
+        restart_failed_background_jobs()


### PR DESCRIPTION
In order to provide a rich display of unavailable content, thumbnails for the missing content is desired. When downloading the starter pack content, request all thumbnails for each channel. This is a new option for the `remotecontentimport` Kolibri task added after 0.16.0-alpha14. The option is ignored on older releases.

#549