### PR TITLE
CI: Fix the missed step id for job's output

### DIFF
--- a/.github/workflows/bump2release.yml
+++ b/.github/workflows/bump2release.yml
@@ -23,7 +23,7 @@ jobs:
       GIT_USERNAME: ${{ github.actor }}
       GIT_USEREMAIL: "${{ github.actor }}@endlessos.org"
     outputs:
-      tagname: ${{ steps.bump_version.outputs.tagname }}
+      tagname: ${{ steps.have_new_tagname.outputs.tagname }}
 
     steps:
       - uses: actions/checkout@v3
@@ -71,6 +71,7 @@ jobs:
           pipenv run yarn bump-version major ${{ inputs.VERSION_NAME }}
 
       - name: Push bump commit & tag to stable branch
+        id: have_new_tagname
         run: |
           git show
 


### PR DESCRIPTION
The build_for_tag job of bump2release.yml will not execute until bump_version job sets the output tagname properly.

This fixes commit 1b8c05e6a04f ("CI: Call the main workflow after bump the version for release").

https://phabricator.endlessm.com/T34804