### PR TITLE
CI: Fix bump_version typo

### DIFF
--- a/.github/workflows/bump2release.yml
+++ b/.github/workflows/bump2release.yml
@@ -91,5 +91,5 @@ jobs:
     if: startsWith(needs.bump_version.outputs.tagname, 'v')
     uses: ./.github/workflows/main.yml
     with:
-      tagname: ${{ needs.bump-version.outputs.tagname }}
+      tagname: ${{ needs.bump_version.outputs.tagname }}
     secrets: inherit


### PR DESCRIPTION
Build_for_tag's following jobs build_apps-bundle and build_kolibri-explore-plugin_whl will not do the release until main.yml's input tagname is set properly.

This fixes commit 1b8c05e6a04f ("CI: Call the main workflow after bump the version for release").

https://phabricator.endlessm.com/T34804