### PR TITLE
setup.py: Use README as the long description for PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 from pathlib import Path
+
 from setuptools import setup
 
 import kolibri_explore_plugin
@@ -18,7 +19,7 @@ setup(
     name=dist_name,
     description=description,
     long_description=long_description,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     version=kolibri_explore_plugin.__version__,
     author="Endless OS Foundation",
     author_email="key@endless.org",

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+from pathlib import Path
 from setuptools import setup
 
 import kolibri_explore_plugin
@@ -9,10 +10,15 @@ dist_name = "kolibri_explore_plugin"
 # Default description of the distributed package
 description = """Kolibri plugin for Endless custom presentation"""
 
+# Use README.md as the long description
+this_directory = Path(__file__).parent
+long_description = (this_directory / "README.md").read_text()
 
 setup(
     name=dist_name,
     description=description,
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     version=kolibri_explore_plugin.__version__,
     author="Endless OS Foundation",
     author_email="key@endless.org",


### PR DESCRIPTION
Use pypa/gh-action-pypi-publish [1] action to publish kolibri-explore-plugin wheel. However, the workflow shows error:

Checking dist/kolibri_explore_plugin-6.4.0-py2.py3-none-any.whl: FAILED
ERROR    `long_description` has syntax errors in markup and would not be
         rendered on PyPI.
         No content rendered from RST source.
WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`.

Follow section "Including your README in your package’s metadata" of the document "Making a PyPI-friendly README" [2] to add "long_description" into setup.py.

[1]: https://github.com/pypa/gh-action-pypi-publish
[2]: https://packaging.python.org/en/latest/guides/making-a-pypi-friendly-readme

Fixes: https://github.com/endlessm/kolibri-explore-plugin/issues/587