### PR TITLE
Filter unavailable content in Channel view

### DIFF
--- a/kolibri_explore_plugin/assets/src/kolibriApi.js
+++ b/kolibri_explore_plugin/assets/src/kolibriApi.js
@@ -105,7 +105,7 @@ class KolibriApi {
 
   searchContent(options) {
     let searchPromise;
-    const { keyword } = options;
+    const { keyword, showUnavailable } = options;
     if (!keyword) {
       searchPromise = Promise.resolve({
         page: 0,
@@ -117,7 +117,7 @@ class KolibriApi {
         getParams: {
           search: keyword,
           channel_id: this.channelId,
-          ...(NO_AVAILABLE_FILTERING && { no_available_filtering: true }),
+          ...(showUnavailable && { no_available_filtering: true }),
         },
       });
     }

--- a/kolibri_explore_plugin/assets/src/kolibriApi.js
+++ b/kolibri_explore_plugin/assets/src/kolibriApi.js
@@ -212,6 +212,10 @@ class KolibriApi {
       window.open(`${deviceContentUrl()}#/content`, '_self');
     }
   }
+
+  get showUnavailableContent() {
+    return NO_AVAILABLE_FILTERING;
+  }
 }
 
 const kolibriApi = new KolibriApi();

--- a/packages/template-ui/src/views/Search.vue
+++ b/packages/template-ui/src/views/Search.vue
@@ -75,8 +75,7 @@ export default {
       resultNodes: [],
       page: null,
       searching: false,
-      // TODO: this needs to come from 'plugin_data'
-      showUnavailable: true,
+      showUnavailable: window.kolibri.showUnavailableContent,
     };
   },
   computed: {

--- a/packages/template-ui/src/views/Search.vue
+++ b/packages/template-ui/src/views/Search.vue
@@ -9,6 +9,16 @@
       @clear-input="onClearInput"
     />
 
+    <b-container>
+      <b-row alignH="between">
+        <b-col>
+          <b-form-checkbox v-model="showUnavailable" name="check-show-unavailable" switch>
+            Show unavailable content
+          </b-form-checkbox>
+        </b-col>
+      </b-row>
+    </b-container>
+
     <EmptyResultsMessage v-if="notFound" :showTopics="false">
       <h1 class="text-secondary">
         Sorry, we can’t find any content that matches your search.
@@ -65,6 +75,8 @@ export default {
       resultNodes: [],
       page: null,
       searching: false,
+      // TODO: this needs to come from 'plugin_data'
+      showUnavailable: true,
     };
   },
   computed: {
@@ -105,10 +117,16 @@ export default {
     searchQuery() {
       this.query = this.searchQuery;
     },
+    showUnavailable() {
+      this.search();
+    },
   },
   methods: {
     search() {
-      return window.kolibri.searchContent({ keyword: this.cleanedQuery })
+      return window.kolibri.searchContent({
+        keyword: this.cleanedQuery,
+        showUnavailable: this.showUnavailable,
+      })
         .then((page) => {
           this.page = page;
           this.resultNodes = page.results;


### PR DESCRIPTION
There are two open questions about this PR:
 * How to handle translatable strings?
 * ~~The initial state of the check button must come from `plugin_data` somehow. How?~~
   * I've worked around this by adding a global getter to the KolibriApi class. It seems to work in practice, but please let me know if the approach is wrong.

Other than that, seems to work.

https://github.com/endlessm/kolibri-explore-plugin/issues/569