### PR TITLE
CI: Fix checkout branch for bump version from wrokflow

### DIFF
--- a/.github/workflows/bump2release.yml
+++ b/.github/workflows/bump2release.yml
@@ -37,7 +37,7 @@ jobs:
           git config --global user.email $GIT_USEREMAIL
 
       - name: Set up Python 3.7
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
 

--- a/.github/workflows/bump2release.yml
+++ b/.github/workflows/bump2release.yml
@@ -42,7 +42,7 @@ jobs:
           python-version: 3.7
 
       - name: Set up Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           # Should be same version as in scripts/bootstrap.sh
           node-version: '16.14.0'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
       with:
         python-version: 3.7
     - name: Set up Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         # Should be same version as in scripts/bootstrap.sh
         node-version: '16.14.0'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Set up Node

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
           python-version: 3.7
 
       - name: Set up Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           # Should be same version as in scripts/bootstrap.sh
           node-version: '16.14.0'
@@ -90,7 +90,7 @@ jobs:
           python-version: 3.7
 
       - name: Set up Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           # Should be same version as in scripts/bootstrap.sh
           node-version: '16.14.0'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout from none-workflow_call
+        uses: actions/checkout@v3
+        if: ${{ !startsWith(inputs.tagname, 'v') }}
+
+      - name: Checkout from workflow_call
+        uses: actions/checkout@v3
+        if: startsWith(inputs.tagname, 'v')
+        with:
+          ref: ${{ inputs.tagname }}
 
       - name: Set up Python 3.7
         uses: actions/setup-python@v2
@@ -41,10 +49,20 @@ jobs:
       - name: Deploy apps
         run: yarn deploy:apps
 
-      - name: Release
+      - name: Release when triggered from a tag push
         uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/') || startsWith(inputs.tagname, 'v')
+        if: startsWith(github.ref, 'refs/tags/')
         with:
+          generate_release_notes: true
+          files: |
+            apps-bundle.zip
+            packages/welcome-screen/welcome-screen.zip
+
+      - name: Release when triggered from workflow_call
+        uses: softprops/action-gh-release@v1
+        if: startsWith(inputs.tagname, 'v')
+        with:
+          tag_name: ${{ inputs.tagname }}
           generate_release_notes: true
           files: |
             apps-bundle.zip
@@ -55,7 +73,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout from none-workflow_call
+        uses: actions/checkout@v3
+        if: ${{ !startsWith(inputs.tagname, 'v') }}
+
+      - name: Checkout from workflow_call
+        uses: actions/checkout@v3
+        if: startsWith(inputs.tagname, 'v')
+        with:
+          ref: ${{ inputs.tagname }}
 
       - name: Set up Python 3.7
         uses: actions/setup-python@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ on:
         default: ''
         required: true
         type: string
+  workflow_dispatch:
 
 jobs:
   build_apps-bundle:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
           ref: ${{ inputs.tagname }}
 
       - name: Set up Python 3.7
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
 
@@ -85,7 +85,7 @@ jobs:
           ref: ${{ inputs.tagname }}
 
       - name: Set up Python 3.7
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
 

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -10,7 +10,7 @@ jobs:
   node10:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Set up Node

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         python-version: 3.7
     - name: Set up Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         # Should be same version as in scripts/bootstrap.sh
         node-version: '16.14.0'


### PR DESCRIPTION
The action/checkout@v3's ref [1] is the reference or SHA when trigger the workflow by default. So, the checkout action will not checkout at the tag until the "ref" is specified with a tag name.

This commit lists the scenarios of both workflow_call and non-workflow_call for action/checkout and softprops/action-gh-release.

[1]: https://github.com/actions/checkout/blob/v3.5.3/README.md#usage

Fixes: https://github.com/endlessm/kolibri-explore-plugin/issues/589