### PR TITLE
Template: Workaround i18n

### DIFF
--- a/packages/template-ui/src/main.js
+++ b/packages/template-ui/src/main.js
@@ -11,6 +11,12 @@ Vue.use(IconsPlugin);
 
 Vue.config.productionTip = false;
 
+// FIXME hook i18n. This is a workaround to allow EK components that
+// use internationalization in the template-ui.
+Vue.prototype.$tr = function $tr(messageId) {
+  return this.$options.$trs[messageId];
+};
+
 dynamicLoadComponents();
 
 window.app = new Vue({


### PR DESCRIPTION
The next commit will add the first translatable EK component. But the i18n from Kolibri isn't hooked with the template-ui. So add a dummy function that will return the English string to avoid the template from failing and to keep Discovery/Library using translations.

Issue: #568