### PR TITLE
Drop NAVIGATE_UNAVAILABLE plugin option

### DIFF
--- a/kolibri_explore_plugin/assets/src/kolibriApi.js
+++ b/kolibri_explore_plugin/assets/src/kolibriApi.js
@@ -1,5 +1,4 @@
 import urls from 'kolibri.urls';
-import plugin_data from 'plugin_data';
 import { ChannelResource, ContentNodeResource, ContentNodeSearchResource } from 'kolibri.resources';
 
 import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
@@ -11,7 +10,7 @@ import { showTopicsContentInLightbox } from './modules/topicsTree/handlers';
 import { PageNames } from './constants';
 import { getChannelIcon } from './customApps';
 
-const NO_AVAILABLE_FILTERING = plugin_data.navigateUnavailable;
+const NO_AVAILABLE_FILTERING = true;
 
 class KolibriApi {
   constructor(channelId) {

--- a/kolibri_explore_plugin/assets/src/modules/coreExplore/actions.js
+++ b/kolibri_explore_plugin/assets/src/modules/coreExplore/actions.js
@@ -1,6 +1,7 @@
-import plugin_data from 'plugin_data';
 import { ChannelResource } from 'kolibri.resources';
 import { pageNameToModuleMap } from '../../constants';
+
+const NO_AVAILABLE_FILTERING = true;
 
 export function resetModuleState(store, lastPageName) {
   const moduleName = pageNameToModuleMap[lastPageName];
@@ -25,7 +26,7 @@ function _channelListState(data) {
 
 // Like upstream setChannelInfo but could also retrieve unavailable channels:
 export function setEkChannelInfo(store) {
-  const getParams = plugin_data.navigateUnavailable ? {} : { available: true };
+  const getParams = NO_AVAILABLE_FILTERING ? {} : { available: true };
   return ChannelResource.fetchCollection({ getParams }).then(
     channelsData => {
       store.commit('SET_CORE_CHANNEL_LIST', _channelListState(channelsData));

--- a/kolibri_explore_plugin/assets/src/modules/topicsRoot/handlers.js
+++ b/kolibri_explore_plugin/assets/src/modules/topicsRoot/handlers.js
@@ -17,7 +17,7 @@ import {
   _collectionState,
 } from '../coreExplore/utils';
 
-const NO_AVAILABLE_FILTERING = plugin_data.navigateUnavailable;
+const NO_AVAILABLE_FILTERING = true;
 
 function _findNodes(channels, channelCollection) {
   // we want them to be in the same order as the channels list

--- a/kolibri_explore_plugin/assets/src/views/SearchPage.vue
+++ b/kolibri_explore_plugin/assets/src/views/SearchPage.vue
@@ -118,7 +118,6 @@
   import _ from 'lodash';
   import { mapMutations, mapState } from 'vuex';
   import { utils, constants, responsiveMixin } from 'ek-components';
-  import plugin_data from 'plugin_data';
 
   import { searchChannelsOnce } from '../modules/topicsRoot/handlers';
   import navigationMixin from '../mixins/navigationMixin';
@@ -128,6 +127,7 @@
   import AboutFooter from '../components/AboutFooter';
 
   const kinds = Object.keys(constants.MediaTypeVerbs);
+  const NO_AVAILABLE_FILTERING = true;
 
   export default {
     name: 'SearchPage',
@@ -149,7 +149,7 @@
         mediaQuality: constants.MediaQuality.REGULAR,
         progress: 100,
         resultKinds: [],
-        showUnavailable: plugin_data.navigateUnavailable,
+        showUnavailable: NO_AVAILABLE_FILTERING,
       };
     },
     computed: {

--- a/kolibri_explore_plugin/kolibri_plugin.py
+++ b/kolibri_explore_plugin/kolibri_plugin.py
@@ -55,9 +55,6 @@ class ExploreAsset(webpack_hooks.WebpackBundleHook):
                 "INITIAL_CONTENT_PACK"
             ],
             "hideDiscoveryTab": conf.OPTIONS["Explore"]["HIDE_DISCOVERY_TAB"],
-            "navigateUnavailable": conf.OPTIONS["Explore"][
-                "NAVIGATE_UNAVAILABLE"
-            ],
         }
 
 

--- a/kolibri_explore_plugin/options.py
+++ b/kolibri_explore_plugin/options.py
@@ -48,13 +48,5 @@ option_spec = {
                 Whether to hide the Discovery tab and redirect to Search.
             """,
         },
-        "NAVIGATE_UNAVAILABLE": {
-            "type": "boolean",
-            "default": False,
-            "description": """
-                Whether to retrieve unavailable channels and content nodes
-                for navigation.
-            """,
-        },
     },
 }


### PR DESCRIPTION
This commit drops the NAVIGATE_UNAVAILABLE option from kolibri-explore-plugin, and hardcodes the behavior to the same as if the option had been set to true.

This does not bring any functional change in comparison to running the plugin with KOLIBRI_NAVIGATE_UNAVAILABLE=1.

https://github.com/endlessm/kolibri-explore-plugin/issues/599