### PR TITLE
Invert show/hide available content logic

### DIFF
--- a/kolibri_explore_plugin/assets/src/kolibriApi.js
+++ b/kolibri_explore_plugin/assets/src/kolibriApi.js
@@ -15,7 +15,7 @@ import {
   retryContentDownload,
 } from './modules/manageContent/handlers';
 
-const DEFAULT_HIDE_UNAVAILABLE = true;
+const DEFAULT_HIDE_UNAVAILABLE = false;
 
 class KolibriApi {
   constructor(channelId) {
@@ -109,7 +109,7 @@ class KolibriApi {
 
   searchContent(options) {
     let searchPromise;
-    const { keyword, hideUnavailable } = options;
+    const { keyword, includeUnavailable } = options;
     if (!keyword) {
       searchPromise = Promise.resolve({
         page: 0,
@@ -121,7 +121,7 @@ class KolibriApi {
         getParams: {
           search: keyword,
           channel_id: this.channelId,
-          ...(hideUnavailable && { no_available_filtering: true }),
+          ...(includeUnavailable && { no_available_filtering: true }),
         },
       });
     }

--- a/kolibri_explore_plugin/assets/src/kolibriApi.js
+++ b/kolibri_explore_plugin/assets/src/kolibriApi.js
@@ -15,7 +15,7 @@ import {
   retryContentDownload,
 } from './modules/manageContent/handlers';
 
-const NO_AVAILABLE_FILTERING = true;
+const DEFAULT_HIDE_UNAVAILABLE = true;
 
 class KolibriApi {
   constructor(channelId) {
@@ -76,7 +76,7 @@ class KolibriApi {
         kind: kind,
         kind_in: kinds,
         descendant_of: options.descendantOf,
-        ...(NO_AVAILABLE_FILTERING && { no_available_filtering: true }),
+        ...(DEFAULT_HIDE_UNAVAILABLE && { no_available_filtering: true }),
       },
     }).then(contentNodes => {
       const { more, results } = contentNodes;
@@ -109,7 +109,7 @@ class KolibriApi {
 
   searchContent(options) {
     let searchPromise;
-    const { keyword, showUnavailable } = options;
+    const { keyword, hideUnavailable } = options;
     if (!keyword) {
       searchPromise = Promise.resolve({
         page: 0,
@@ -121,7 +121,7 @@ class KolibriApi {
         getParams: {
           search: keyword,
           channel_id: this.channelId,
-          ...(showUnavailable && { no_available_filtering: true }),
+          ...(hideUnavailable && { no_available_filtering: true }),
         },
       });
     }
@@ -227,8 +227,8 @@ class KolibriApi {
     }
   }
 
-  get showUnavailableContent() {
-    return NO_AVAILABLE_FILTERING;
+  get defaultHideUnavailable() {
+    return DEFAULT_HIDE_UNAVAILABLE;
   }
 }
 

--- a/kolibri_explore_plugin/assets/src/kolibriApi.js
+++ b/kolibri_explore_plugin/assets/src/kolibriApi.js
@@ -76,7 +76,7 @@ class KolibriApi {
         kind: kind,
         kind_in: kinds,
         descendant_of: options.descendantOf,
-        ...(DEFAULT_HIDE_UNAVAILABLE && { no_available_filtering: true }),
+        no_available_filtering: true,
       },
     }).then(contentNodes => {
       const { more, results } = contentNodes;

--- a/kolibri_explore_plugin/assets/src/modules/coreExplore/actions.js
+++ b/kolibri_explore_plugin/assets/src/modules/coreExplore/actions.js
@@ -1,8 +1,6 @@
 import { ChannelResource } from 'kolibri.resources';
 import { pageNameToModuleMap } from '../../constants';
 
-const DEFAULT_HIDE_UNAVAILABLE = true;
-
 export function resetModuleState(store, lastPageName) {
   const moduleName = pageNameToModuleMap[lastPageName];
   if (moduleName) {
@@ -24,10 +22,9 @@ function _channelListState(data) {
   }));
 }
 
-// Like upstream setChannelInfo but could also retrieve unavailable channels:
+// Like upstream setChannelInfo but also retrieves unavailable channels:
 export function setEkChannelInfo(store) {
-  const getParams = DEFAULT_HIDE_UNAVAILABLE ? {} : { available: true };
-  return ChannelResource.fetchCollection({ getParams }).then(
+  return ChannelResource.fetchCollection().then(
     channelsData => {
       store.commit('SET_CORE_CHANNEL_LIST', _channelListState(channelsData));
       return channelsData;

--- a/kolibri_explore_plugin/assets/src/modules/coreExplore/actions.js
+++ b/kolibri_explore_plugin/assets/src/modules/coreExplore/actions.js
@@ -1,7 +1,7 @@
 import { ChannelResource } from 'kolibri.resources';
 import { pageNameToModuleMap } from '../../constants';
 
-const NO_AVAILABLE_FILTERING = true;
+const DEFAULT_HIDE_UNAVAILABLE = true;
 
 export function resetModuleState(store, lastPageName) {
   const moduleName = pageNameToModuleMap[lastPageName];
@@ -26,7 +26,7 @@ function _channelListState(data) {
 
 // Like upstream setChannelInfo but could also retrieve unavailable channels:
 export function setEkChannelInfo(store) {
-  const getParams = NO_AVAILABLE_FILTERING ? {} : { available: true };
+  const getParams = DEFAULT_HIDE_UNAVAILABLE ? {} : { available: true };
   return ChannelResource.fetchCollection({ getParams }).then(
     channelsData => {
       store.commit('SET_CORE_CHANNEL_LIST', _channelListState(channelsData));

--- a/kolibri_explore_plugin/assets/src/modules/topicsRoot/handlers.js
+++ b/kolibri_explore_plugin/assets/src/modules/topicsRoot/handlers.js
@@ -17,7 +17,7 @@ import {
   _collectionState,
 } from '../coreExplore/utils';
 
-const NO_AVAILABLE_FILTERING = true;
+const DEFAULT_HIDE_UNAVAILABLE = true;
 
 function _findNodes(channels, channelCollection) {
   // we want them to be in the same order as the channels list
@@ -208,7 +208,7 @@ export function showChannels(store) {
           getParams: {
             ids: channelRootIds,
             user_kind: store.getters.getUserKind,
-            ...(NO_AVAILABLE_FILTERING && { no_available_filtering: true }),
+            ...(DEFAULT_HIDE_UNAVAILABLE && { no_available_filtering: true }),
           },
         })
           .then(collection => _findNodes(channels, collection))

--- a/kolibri_explore_plugin/assets/src/modules/topicsRoot/handlers.js
+++ b/kolibri_explore_plugin/assets/src/modules/topicsRoot/handlers.js
@@ -17,8 +17,6 @@ import {
   _collectionState,
 } from '../coreExplore/utils';
 
-const DEFAULT_HIDE_UNAVAILABLE = true;
-
 function _findNodes(channels, channelCollection) {
   // we want them to be in the same order as the channels list
   return channels
@@ -208,7 +206,7 @@ export function showChannels(store) {
           getParams: {
             ids: channelRootIds,
             user_kind: store.getters.getUserKind,
-            ...(DEFAULT_HIDE_UNAVAILABLE && { no_available_filtering: true }),
+            no_available_filtering: true,
           },
         })
           .then(collection => _findNodes(channels, collection))

--- a/kolibri_explore_plugin/assets/src/views/SearchPage.vue
+++ b/kolibri_explore_plugin/assets/src/views/SearchPage.vue
@@ -23,8 +23,8 @@
         <b-container>
           <b-row alignH="between">
             <b-col>
-              <b-form-checkbox v-model="showUnavailable" name="check-show-unavailable" switch>
-                {{ $tr('showUnavailableLabel') }}
+              <b-form-checkbox v-model="hideUnavailable" name="check-hide-unavailable" switch>
+                {{ $tr('hideUnavailableLabel') }}
               </b-form-checkbox>
             </b-col>
             <b-col class="text-right">
@@ -127,7 +127,7 @@
   import AboutFooter from '../components/AboutFooter';
 
   const kinds = Object.keys(constants.MediaTypeVerbs);
-  const NO_AVAILABLE_FILTERING = true;
+  const DEFAULT_HIDE_UNAVAILABLE = true;
 
   export default {
     name: 'SearchPage',
@@ -149,7 +149,7 @@
         mediaQuality: constants.MediaQuality.REGULAR,
         progress: 100,
         resultKinds: [],
-        showUnavailable: NO_AVAILABLE_FILTERING,
+        hideUnavailable: DEFAULT_HIDE_UNAVAILABLE,
       };
     },
     computed: {
@@ -239,7 +239,7 @@
       searchTerm() {
         this.query = this.searchTerm || '';
       },
-      showUnavailable() {
+      hideUnavailable() {
         this.setSearchTerm(this.query);
         this.search(this.cleanedQuery);
       },
@@ -266,7 +266,7 @@
 
         this.progress = 0;
         kinds.forEach(k => {
-          searchChannelsOnce(this.$store, query, k, this.showUnavailable).then(() => {
+          searchChannelsOnce(this.$store, query, k, this.hideUnavailable).then(() => {
             this.resultKinds.push(k);
             this.progress += 100 / kinds.length;
           });
@@ -286,7 +286,7 @@
     },
     $trs: {
       documentTitle: 'Library',
-      showUnavailableLabel: 'Show unavailable content',
+      hideUnavailableLabel: 'Show unavailable content',
     },
   };
 

--- a/kolibri_explore_plugin/assets/src/views/SearchPage.vue
+++ b/kolibri_explore_plugin/assets/src/views/SearchPage.vue
@@ -127,7 +127,7 @@
   import AboutFooter from '../components/AboutFooter';
 
   const kinds = Object.keys(constants.MediaTypeVerbs);
-  const DEFAULT_HIDE_UNAVAILABLE = true;
+  const DEFAULT_HIDE_UNAVAILABLE = false;
 
   export default {
     name: 'SearchPage',
@@ -266,7 +266,7 @@
 
         this.progress = 0;
         kinds.forEach(k => {
-          searchChannelsOnce(this.$store, query, k, this.hideUnavailable).then(() => {
+          searchChannelsOnce(this.$store, query, k, !this.hideUnavailable).then(() => {
             this.resultKinds.push(k);
             this.progress += 100 / kinds.length;
           });
@@ -286,7 +286,7 @@
     },
     $trs: {
       documentTitle: 'Library',
-      hideUnavailableLabel: 'Show unavailable content',
+      hideUnavailableLabel: 'Only downloaded items',
     },
   };
 

--- a/packages/template-ui/src/views/Search.vue
+++ b/packages/template-ui/src/views/Search.vue
@@ -12,7 +12,7 @@
     <b-container>
       <b-row alignH="between">
         <b-col>
-          <b-form-checkbox v-model="showUnavailable" name="check-show-unavailable" switch>
+          <b-form-checkbox v-model="hideUnavailable" name="check-hide-unavailable" switch>
             Show unavailable content
           </b-form-checkbox>
         </b-col>
@@ -75,7 +75,7 @@ export default {
       resultNodes: [],
       page: null,
       searching: false,
-      showUnavailable: window.kolibri.showUnavailableContent,
+      hideUnavailable: window.kolibri.defaultHideUnavailable,
     };
   },
   computed: {
@@ -116,7 +116,7 @@ export default {
     searchQuery() {
       this.query = this.searchQuery;
     },
-    showUnavailable() {
+    hideUnavailable() {
       this.search();
     },
   },
@@ -124,7 +124,7 @@ export default {
     search() {
       return window.kolibri.searchContent({
         keyword: this.cleanedQuery,
-        showUnavailable: this.showUnavailable,
+        hideUnavailable: this.hideUnavailable,
       })
         .then((page) => {
           this.page = page;

--- a/packages/template-ui/src/views/Search.vue
+++ b/packages/template-ui/src/views/Search.vue
@@ -13,7 +13,7 @@
       <b-row alignH="between">
         <b-col>
           <b-form-checkbox v-model="hideUnavailable" name="check-hide-unavailable" switch>
-            Show unavailable content
+            Only downloaded items
           </b-form-checkbox>
         </b-col>
       </b-row>
@@ -124,7 +124,7 @@ export default {
     search() {
       return window.kolibri.searchContent({
         keyword: this.cleanedQuery,
-        hideUnavailable: this.hideUnavailable,
+        includeUnavailable: !this.hideUnavailable,
       })
         .then((page) => {
           this.page = page;


### PR DESCRIPTION
Invert the logic so when the UI component is active the content that is
not downloaded on the device is hidden.
    
https://github.com/endlessm/kolibri-explore-plugin/issues/596