### PR TITLE
options: Allow feedback URL to be configured

### DIFF
--- a/kolibri_explore_plugin/assets/src/components/DiscoveryNavBar.vue
+++ b/kolibri_explore_plugin/assets/src/components/DiscoveryNavBar.vue
@@ -23,6 +23,7 @@
     </b-button-group>
     <b-navbar-nav>
       <b-nav-item
+        v-if="showFeedbackButton"
         class="d-block pr-0"
         :href="feedbackUrl"
         target="_blank"
@@ -65,7 +66,10 @@
         return assets.EndlessLogo;
       },
       feedbackUrl() {
-        return 'https://endlessos.org/key-feedback';
+        return plugin_data.feedbackUrl;
+      },
+      showFeedbackButton() {
+        return plugin_data.feedbackUrl != '';
       },
       showDiscoveryTab() {
         return !plugin_data.hideDiscoveryTab;

--- a/kolibri_explore_plugin/kolibri_plugin.py
+++ b/kolibri_explore_plugin/kolibri_plugin.py
@@ -55,6 +55,7 @@ class ExploreAsset(webpack_hooks.WebpackBundleHook):
                 "INITIAL_CONTENT_PACK"
             ],
             "hideDiscoveryTab": conf.OPTIONS["Explore"]["HIDE_DISCOVERY_TAB"],
+            "feedbackUrl": conf.OPTIONS["Explore"]["FEEDBACK_URL"],
         }
 
 

--- a/kolibri_explore_plugin/options.py
+++ b/kolibri_explore_plugin/options.py
@@ -48,5 +48,13 @@ option_spec = {
                 Whether to hide the Discovery tab and redirect to Search.
             """,
         },
+        "FEEDBACK_URL": {
+            "type": "string",
+            "default": "https://endlessos.org/key-feedback",
+            "description": """
+                Form to link to from the Feedback button, or the empty string
+                to hide it
+            """,
+        },
     },
 }


### PR DESCRIPTION
This will allow the feedback form to differ between the offline and online Kolibri instances.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

Fixes: https://github.com/endlessm/endless-key-content-private/issues/62