### PR TITLE
handlers: Work around cards not being loaded when app starts

### DIFF
--- a/kolibri_explore_plugin/assets/src/modules/topicsRoot/handlers.js
+++ b/kolibri_explore_plugin/assets/src/modules/topicsRoot/handlers.js
@@ -180,6 +180,7 @@ export function decideDownload(store) {
             store.commit('CORE_SET_PAGE_LOADING', false);
             store.commit('CORE_SET_ERROR', null);
           }
+          location.reload();
         });
       }
     }


### PR DESCRIPTION
This forces a reload of the main page when the app starts, to work around a problem where the cards never finish loading on that page.

https://github.com/endlessm/kolibri-explore-plugin/issues/598