### PR TITLE
Startup: Don't fetch carousel for collections

### DIFF
--- a/kolibri_explore_plugin/assets/src/modules/topicsRoot/handlers.js
+++ b/kolibri_explore_plugin/assets/src/modules/topicsRoot/handlers.js
@@ -59,6 +59,11 @@ function _findNodes(channels, channelCollection) {
 }
 
 function _fetchCarouselNodes(store) {
+  if (!plugin_data.useEkIguanaPage) {
+    // These carousel nodes are only relevant to EK Iguana:
+    return Promise.resolve([]);
+  }
+
   const { rootNodes } = store.state.topicsRoot;
   const highlightedContentUrl = urls.static(`highlighted-content.json`);
 


### PR DESCRIPTION
These hardcoded nodes are for EK Iguana (USB) which has a fixed presentation. But the dynamic collections don't have them, so they are provoking 404s and doing unneeded calculations on startup.

#598