### PR TITLE
CI: Only run workflows on push to master or stable

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,9 @@
 name: Lint
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master, stable]
+  pull_request:
 
 jobs:
   lint:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,7 @@ name: Build
 
 on:
   push:
+    branches: [master, stable]
   pull_request:
   workflow_call:
     inputs:

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -2,9 +2,8 @@ name: Yarn build
 
 on:
   push:
-    branches: [ master ]
+    branches: [master, stable]
   pull_request:
-    branches: [ master ]
 
 jobs:
   node10:


### PR DESCRIPTION
Currently when you open a PR, the Build and Lint workflows run twice because they run on any push event in addition to the pull request event. Instead, limit the push events to the master or stable branch.