### PR TITLE
Vendor old file download code

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+extend-exclude =
+  build/,
+  static/,
+  dist/,
+  node_modules/

--- a/.flake8
+++ b/.flake8
@@ -3,4 +3,5 @@ extend-exclude =
   build/,
   static/,
   dist/,
-  node_modules/
+  node_modules/,
+  kolibri_explore_plugin/vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -5,13 +5,15 @@ node_modules
 # vscode files
 .vscode/
 
+# Compiled python modules
+__pycache__/
+
 # Built and cached files
 kolibri_explore_plugin/apps/**/*.zip
 kolibri_explore_plugin/welcomeScreen/
 kolibri_explore_plugin/static/kolibri_explore_plugin*
 kolibri_explore_plugin/static/build-info.json
 kolibri_explore_plugin/build/
-kolibri_explore_plugin/__pycache__
 build/
 dist/
 kolibri_explore_plugin.egg-info/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: (\.git/|\.tox/|\.venv/|build/|static/|dist/|node_modules/)
+exclude: (\.git/|\.tox/|\.venv/|build/|static/|dist/|node_modules/|kolibri_explore_plugin/vendor/)
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v2.0.0

--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ pre-commit = "==2.15.0"
 twine = "*"
 bumpversion = "*"
 wheel = "*"
+requests = "==2.27.1"
 
 [requires]
 python_version = "3"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "345c0b7088a2c53604be98f5cc321af492819d7ed0b81692a82f53847025d7cc"
+            "sha256": "799a7a77e926e638112dd1118aebcf8cd2990a24416787064ab648ce53fd79f3"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -141,109 +141,36 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:04afa6387e2b282cf78ff3dbce20f0cc071c12dc8f685bd40960cc68644cfea6",
-                "sha256:04eefcee095f58eaabe6dc3cc2262f3bcd776d2c67005880894f447b3f2cb9c1",
-                "sha256:0be65ccf618c1e7ac9b849c315cc2e8a8751d9cfdaa43027d4f6624bd587ab7e",
-                "sha256:0c95f12b74681e9ae127728f7e5409cbbef9cd914d5896ef238cc779b8152373",
-                "sha256:0ca564606d2caafb0abe6d1b5311c2649e8071eb241b2d64e75a0d0065107e62",
-                "sha256:10c93628d7497c81686e8e5e557aafa78f230cd9e77dd0c40032ef90c18f2230",
-                "sha256:11d117e6c63e8f495412d37e7dc2e2fff09c34b2d09dbe2bee3c6229577818be",
-                "sha256:11d3bcb7be35e7b1bba2c23beedac81ee893ac9871d0ba79effc7fc01167db6c",
-                "sha256:12a2b561af122e3d94cdb97fe6fb2bb2b82cef0cdca131646fdb940a1eda04f0",
-                "sha256:12d1a39aa6b8c6f6248bb54550efcc1c38ce0d8096a146638fd4738e42284448",
-                "sha256:1435ae15108b1cb6fffbcea2af3d468683b7afed0169ad718451f8db5d1aff6f",
-                "sha256:1c60b9c202d00052183c9be85e5eaf18a4ada0a47d188a83c8f5c5b23252f649",
-                "sha256:1e8fcdd8f672a1c4fc8d0bd3a2b576b152d2a349782d1eb0f6b8e52e9954731d",
-                "sha256:20064ead0717cf9a73a6d1e779b23d149b53daf971169289ed2ed43a71e8d3b0",
-                "sha256:21fa558996782fc226b529fdd2ed7866c2c6ec91cee82735c98a197fae39f706",
-                "sha256:22908891a380d50738e1f978667536f6c6b526a2064156203d418f4856d6e86a",
-                "sha256:3160a0fd9754aab7d47f95a6b63ab355388d890163eb03b2d2b87ab0a30cfa59",
-                "sha256:322102cdf1ab682ecc7d9b1c5eed4ec59657a65e1c146a0da342b78f4112db23",
-                "sha256:34e0a2f9c370eb95597aae63bf85eb5e96826d81e3dcf88b8886012906f509b5",
-                "sha256:3573d376454d956553c356df45bb824262c397c6e26ce43e8203c4c540ee0acb",
-                "sha256:3747443b6a904001473370d7810aa19c3a180ccd52a7157aacc264a5ac79265e",
-                "sha256:38e812a197bf8e71a59fe55b757a84c1f946d0ac114acafaafaf21667a7e169e",
-                "sha256:3a06f32c9634a8705f4ca9946d667609f52cf130d5548881401f1eb2c39b1e2c",
-                "sha256:3a5fc78f9e3f501a1614a98f7c54d3969f3ad9bba8ba3d9b438c3bc5d047dd28",
-                "sha256:3d9098b479e78c85080c98e1e35ff40b4a31d8953102bb0fd7d1b6f8a2111a3d",
-                "sha256:3dc5b6a8ecfdc5748a7e429782598e4f17ef378e3e272eeb1340ea57c9109f41",
-                "sha256:4155b51ae05ed47199dc5b2a4e62abccb274cee6b01da5b895099b61b1982974",
-                "sha256:49919f8400b5e49e961f320c735388ee686a62327e773fa5b3ce6721f7e785ce",
-                "sha256:53d0a3fa5f8af98a1e261de6a3943ca631c526635eb5817a87a59d9a57ebf48f",
-                "sha256:5f008525e02908b20e04707a4f704cd286d94718f48bb33edddc7d7b584dddc1",
-                "sha256:628c985afb2c7d27a4800bfb609e03985aaecb42f955049957814e0491d4006d",
-                "sha256:65ed923f84a6844de5fd29726b888e58c62820e0769b76565480e1fdc3d062f8",
-                "sha256:6734e606355834f13445b6adc38b53c0fd45f1a56a9ba06c2058f86893ae8017",
-                "sha256:6baf0baf0d5d265fa7944feb9f7451cc316bfe30e8df1a61b1bb08577c554f31",
-                "sha256:6f4f4668e1831850ebcc2fd0b1cd11721947b6dc7c00bf1c6bd3c929ae14f2c7",
-                "sha256:6f5c2e7bc8a4bf7c426599765b1bd33217ec84023033672c1e9a8b35eaeaaaf8",
-                "sha256:6f6c7a8a57e9405cad7485f4c9d3172ae486cfef1344b5ddd8e5239582d7355e",
-                "sha256:7381c66e0561c5757ffe616af869b916c8b4e42b367ab29fedc98481d1e74e14",
-                "sha256:73dc03a6a7e30b7edc5b01b601e53e7fc924b04e1835e8e407c12c037e81adbd",
-                "sha256:74db0052d985cf37fa111828d0dd230776ac99c740e1a758ad99094be4f1803d",
-                "sha256:75f2568b4189dda1c567339b48cba4ac7384accb9c2a7ed655cd86b04055c795",
-                "sha256:78cacd03e79d009d95635e7d6ff12c21eb89b894c354bd2b2ed0b4763373693b",
-                "sha256:80d1543d58bd3d6c271b66abf454d437a438dff01c3e62fdbcd68f2a11310d4b",
-                "sha256:830d2948a5ec37c386d3170c483063798d7879037492540f10a475e3fd6f244b",
-                "sha256:891cf9b48776b5c61c700b55a598621fdb7b1e301a550365571e9624f270c203",
-                "sha256:8f25e17ab3039b05f762b0a55ae0b3632b2e073d9c8fc88e89aca31a6198e88f",
-                "sha256:9a3267620866c9d17b959a84dd0bd2d45719b817245e49371ead79ed4f710d19",
-                "sha256:a04f86f41a8916fe45ac5024ec477f41f886b3c435da2d4e3d2709b22ab02af1",
-                "sha256:aaf53a6cebad0eae578f062c7d462155eada9c172bd8c4d250b8c1d8eb7f916a",
-                "sha256:abc1185d79f47c0a7aaf7e2412a0eb2c03b724581139193d2d82b3ad8cbb00ac",
-                "sha256:ac0aa6cd53ab9a31d397f8303f92c42f534693528fafbdb997c82bae6e477ad9",
-                "sha256:ac3775e3311661d4adace3697a52ac0bab17edd166087d493b52d4f4f553f9f0",
-                "sha256:b06f0d3bf045158d2fb8837c5785fe9ff9b8c93358be64461a1089f5da983137",
-                "sha256:b116502087ce8a6b7a5f1814568ccbd0e9f6cfd99948aa59b0e241dc57cf739f",
-                "sha256:b82fab78e0b1329e183a65260581de4375f619167478dddab510c6c6fb04d9b6",
-                "sha256:bd7163182133c0c7701b25e604cf1611c0d87712e56e88e7ee5d72deab3e76b5",
-                "sha256:c36bcbc0d5174a80d6cccf43a0ecaca44e81d25be4b7f90f0ed7bcfbb5a00909",
-                "sha256:c3af8e0f07399d3176b179f2e2634c3ce9c1301379a6b8c9c9aeecd481da494f",
-                "sha256:c84132a54c750fda57729d1e2599bb598f5fa0344085dbde5003ba429a4798c0",
-                "sha256:cb7b2ab0188829593b9de646545175547a70d9a6e2b63bf2cd87a0a391599324",
-                "sha256:cca4def576f47a09a943666b8f829606bcb17e2bc2d5911a46c8f8da45f56755",
-                "sha256:cf6511efa4801b9b38dc5546d7547d5b5c6ef4b081c60b23e4d941d0eba9cbeb",
-                "sha256:d16fd5252f883eb074ca55cb622bc0bee49b979ae4e8639fff6ca3ff44f9f854",
-                "sha256:d2686f91611f9e17f4548dbf050e75b079bbc2a82be565832bc8ea9047b61c8c",
-                "sha256:d7fc3fca01da18fbabe4625d64bb612b533533ed10045a2ac3dd194bfa656b60",
-                "sha256:dd5653e67b149503c68c4018bf07e42eeed6b4e956b24c00ccdf93ac79cdff84",
-                "sha256:de5695a6f1d8340b12a5d6d4484290ee74d61e467c39ff03b39e30df62cf83a0",
-                "sha256:e0ac8959c929593fee38da1c2b64ee9778733cdf03c482c9ff1d508b6b593b2b",
-                "sha256:e1b25e3ad6c909f398df8921780d6a3d120d8c09466720226fc621605b6f92b1",
-                "sha256:e633940f28c1e913615fd624fcdd72fdba807bf53ea6925d6a588e84e1151531",
-                "sha256:e89df2958e5159b811af9ff0f92614dabf4ff617c03a4c1c6ff53bf1c399e0e1",
-                "sha256:ea9f9c6034ea2d93d9147818f17c2a0860d41b71c38b9ce4d55f21b6f9165a11",
-                "sha256:f645caaf0008bacf349875a974220f1f1da349c5dbe7c4ec93048cdc785a3326",
-                "sha256:f8303414c7b03f794347ad062c0516cee0e15f7a612abd0ce1e25caf6ceb47df",
-                "sha256:fca62a8301b605b954ad2e9c3666f9d97f63872aa4efcae5492baca2056b74ab"
+                "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
+                "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==3.1.0"
+            "markers": "python_version >= '3'",
+            "version": "==2.0.12"
         },
         "cryptography": {
             "hashes": [
-                "sha256:0ddaee209d1cf1f180f1efa338a68c4621154de0afaef92b89486f5f96047c55",
-                "sha256:14754bcdae909d66ff24b7b5f166d69340ccc6cb15731670435efd5719294895",
-                "sha256:344c6de9f8bda3c425b3a41b319522ba3208551b70c2ae00099c205f0d9fd3be",
-                "sha256:34d405ea69a8b34566ba3dfb0521379b210ea5d560fafedf9f800a9a94a41928",
-                "sha256:3680248309d340fda9611498a5319b0193a8dbdb73586a1acf8109d06f25b92d",
-                "sha256:3c5ef25d060c80d6d9f7f9892e1d41bb1c79b78ce74805b8cb4aa373cb7d5ec8",
-                "sha256:4ab14d567f7bbe7f1cdff1c53d5324ed4d3fc8bd17c481b395db224fb405c237",
-                "sha256:5c1f7293c31ebc72163a9a0df246f890d65f66b4a40d9ec80081969ba8c78cc9",
-                "sha256:6b71f64beeea341c9b4f963b48ee3b62d62d57ba93eb120e1196b31dc1025e78",
-                "sha256:7d92f0248d38faa411d17f4107fc0bce0c42cae0b0ba5415505df72d751bf62d",
-                "sha256:8362565b3835ceacf4dc8f3b56471a2289cf51ac80946f9087e66dc283a810e0",
-                "sha256:84a165379cb9d411d58ed739e4af3396e544eac190805a54ba2e0322feb55c46",
-                "sha256:88ff107f211ea696455ea8d911389f6d2b276aabf3231bf72c8853d22db755c5",
-                "sha256:9f65e842cb02550fac96536edb1d17f24c0a338fd84eaf582be25926e993dde4",
-                "sha256:a4fc68d1c5b951cfb72dfd54702afdbbf0fb7acdc9b7dc4301bbf2225a27714d",
-                "sha256:b7f2f5c525a642cecad24ee8670443ba27ac1fab81bba4cc24c7b6b41f2d0c75",
-                "sha256:b846d59a8d5a9ba87e2c3d757ca019fa576793e8758174d3868aecb88d6fc8eb",
-                "sha256:bf8fc66012ca857d62f6a347007e166ed59c0bc150cefa49f28376ebe7d992a2",
-                "sha256:f5d0bf9b252f30a31664b6f64432b4730bb7038339bd18b1fafe129cfc2be9be"
+                "sha256:059e348f9a3c1950937e1b5d7ba1f8e968508ab181e75fc32b879452f08356db",
+                "sha256:1a5472d40c8f8e91ff7a3d8ac6dfa363d8e3138b961529c996f3e2df0c7a411a",
+                "sha256:1a8e6c2de6fbbcc5e14fd27fb24414507cb3333198ea9ab1258d916f00bc3039",
+                "sha256:1fee5aacc7367487b4e22484d3c7e547992ed726d14864ee33c0176ae43b0d7c",
+                "sha256:5d092fdfedaec4cbbffbf98cddc915ba145313a6fdaab83c6e67f4e6c218e6f3",
+                "sha256:5f0ff6e18d13a3de56f609dd1fd11470918f770c6bd5d00d632076c727d35485",
+                "sha256:7bfc55a5eae8b86a287747053140ba221afc65eb06207bedf6e019b8934b477c",
+                "sha256:7fa01527046ca5facdf973eef2535a27fec4cb651e4daec4d043ef63f6ecd4ca",
+                "sha256:8dde71c4169ec5ccc1087bb7521d54251c016f126f922ab2dfe6649170a3b8c5",
+                "sha256:8f4ab7021127a9b4323537300a2acfb450124b2def3756f64dc3a3d2160ee4b5",
+                "sha256:948224d76c4b6457349d47c0c98657557f429b4e93057cf5a2f71d603e2fc3a3",
+                "sha256:9a6c7a3c87d595608a39980ebaa04d5a37f94024c9f24eb7d10262b92f739ddb",
+                "sha256:b46e37db3cc267b4dea1f56da7346c9727e1209aa98487179ee8ebed09d21e43",
+                "sha256:b4ceb5324b998ce2003bc17d519080b4ec8d5b7b70794cbd2836101406a9be31",
+                "sha256:cb33ccf15e89f7ed89b235cff9d49e2e62c6c981a6061c9c8bb47ed7951190bc",
+                "sha256:d198820aba55660b4d74f7b5fd1f17db3aa5eb3e6893b0a41b75e84e4f9e0e4b",
+                "sha256:d34579085401d3f49762d2f7d6634d6b6c2ae1242202e860f4d26b046e3a1006",
+                "sha256:eb8163f5e549a22888c18b0d53d6bb62a20510060a22fd5a995ec8a05268df8a",
+                "sha256:f73bff05db2a3e5974a6fd248af2566134d8981fd7ab012e5dd4ddb1d9a70699"
             ],
-            "index": "pypi",
-            "version": "==41.0.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==41.0.1"
         },
         "decorator": {
             "hashes": [
@@ -277,11 +204,11 @@
         },
         "filelock": {
             "hashes": [
-                "sha256:ad98852315c2ab702aeb628412cbf7e95b7ce8c3bf9565670b4eaecf1db370a9",
-                "sha256:fc03ae43288c013d2ea83c8597001b1129db351aad9c57fe2409327916b8e718"
+                "sha256:002740518d8aa59a26b0c76e10fb8c6e15eae825d34b6fdf670333fd7b938d81",
+                "sha256:cbb791cdea2a72f23da6ac5b5269ab0a0d161e9ef0100e653b69049a7706d1ec"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.12.0"
+            "version": "==3.12.2"
         },
         "flake8": {
             "hashes": [
@@ -304,7 +231,7 @@
                 "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",
                 "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
             ],
-            "markers": "python_version >= '3.5'",
+            "markers": "python_version >= '3'",
             "version": "==3.4"
         },
         "importlib-metadata": {
@@ -327,7 +254,7 @@
                 "sha256:1d197b907b6ba441b692c48cf2a3a2de280dc0ac91a3405b39349a50272ca0a1",
                 "sha256:248aca623f5c99a6635bc3857677b7320b9b8039f99f070ee0d20a5ca5a8e6bf"
             ],
-            "markers": "python_version >= '3.9'",
+            "markers": "python_version >= '3.4'",
             "version": "==8.14.0"
         },
         "jaraco.classes": {
@@ -364,11 +291,11 @@
         },
         "markdown-it-py": {
             "hashes": [
-                "sha256:5a35f8d1870171d9acc47b99612dc146129b631baf04970128b568f190d0cc30",
-                "sha256:7c9a5e412688bc771c67432cbfebcdd686c93ce6484913dccf06cb5a0bea35a1"
+                "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1",
+                "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.2.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==3.0.0"
         },
         "matplotlib-inline": {
             "hashes": [
@@ -441,11 +368,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:412dae91f52a6f84830f39a8078cecd0e866cb72294a5c66808e74d5e88d251f",
-                "sha256:e2378146f1964972c03c085bb5662ae80b2b8c06226c54b2ff4aa9483e8a13a5"
+                "sha256:0ade98a4895e87dc51d47151f7d2ec290365a585151d97b4d8d6312ed6132fed",
+                "sha256:e48fabd87db8f3a7df7150a4a5ea22c546ee8bc39bc2473244730d4b56d2cc4e"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.5.1"
+            "version": "==3.5.3"
         },
         "pre-commit": {
             "hashes": [
@@ -460,7 +387,7 @@
                 "sha256:23ac5d50538a9a38c8bde05fecb47d0b403ecd0662857a86f886f798563d5b9b",
                 "sha256:45ea77a2f7c60418850331366c81cf6b5b9cf4c7fd34616f733c5427e6abbb1f"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_full_version >= '3.7.0'",
             "version": "==3.0.38"
         },
         "ptyprocess": {
@@ -565,11 +492,11 @@
         },
         "requests": {
             "hashes": [
-                "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f",
-                "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"
+                "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61",
+                "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.31.0"
+            "index": "pypi",
+            "version": "==2.27.1"
         },
         "requests-toolbelt": {
             "hashes": [
@@ -589,11 +516,11 @@
         },
         "rich": {
             "hashes": [
-                "sha256:76f6b65ea7e5c5d924ba80e322231d7cb5b5981aa60bfc1e694f1bc097fe6fe1",
-                "sha256:d204aadb50b936bf6b1a695385429d192bc1fdaf3e8b907e8e26f4c4e4b5bf75"
+                "sha256:8f87bc7ee54675732fa66a05ebfe489e27264caeeff3728c945d25971b6485ec",
+                "sha256:d653d6bccede5844304c605d5aac802c7cf9621efd700b46c7ec2b51ea914898"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==13.4.1"
+            "markers": "python_full_version >= '3.7.0'",
+            "version": "==13.4.2"
         },
         "secretstorage": {
             "hashes": [
@@ -650,21 +577,28 @@
             "index": "pypi",
             "version": "==4.0.2"
         },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:88a4153d8505aabbb4e13aacb7c486c2b4a33ca3b3f807914a9b4c844c471c26",
+                "sha256:d91d5919357fe7f681a9f2b5b4cb2a5f1ef0a1e9f59c4d8ff0d3491e05c0ffd5"
+            ],
+            "markers": "python_version < '3.10'",
+            "version": "==4.6.3"
+        },
         "urllib3": {
             "hashes": [
-                "sha256:61717a1095d7e155cdb737ac7bb2f4324a858a1e2e6466f6d03ff630ca68d3cc",
-                "sha256:d055c2f9d38dc53c808f6fdc8eab7360b6fdbbde02340ed25cfbcd817c62469e"
+                "sha256:8d36afa7616d8ab714608411b4a3b13e58f463aee519024578e062e141dce20f",
+                "sha256:8f135f6502756bde6b2a9b28989df5fbe87c9970cecaa69041edcce7f0589b14"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.0.2"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==1.26.16"
         },
         "virtualenv": {
             "hashes": [
-                "sha256:6abec7670e5802a528357fdc75b26b9f57d5d92f29c5462ba0fbe45feacc685e",
-                "sha256:a85caa554ced0c0afbd0d638e7e2d7b5f92d23478d05d17a76daeac8f279f924"
+                "sha256:34da10f14fea9be20e0fd7f04aba9732f84e593dac291b757ce42e3368a39419"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==20.23.0"
+            "version": "==20.23.1"
         },
         "wcwidth": {
             "hashes": [

--- a/kolibri_explore_plugin/collectionviews.py
+++ b/kolibri_explore_plugin/collectionviews.py
@@ -8,7 +8,6 @@ from django.utils.translation import gettext_lazy as _
 from kolibri.core.content.errors import InsufficientStorageSpaceError
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.tasks import remotechannelimport
-from kolibri.core.content.tasks import remotecontentimport
 from kolibri.core.content.utils.content_manifest import ContentManifest
 from kolibri.core.content.utils.content_manifest import (
     ContentManifestParseError,
@@ -24,6 +23,7 @@ from rest_framework.response import Response
 
 from .tasks import applyexternaltags
 from .tasks import QUEUE
+from .tasks import remotecontentimport
 
 logger = logging.getLogger(__name__)
 

--- a/kolibri_explore_plugin/tasks.py
+++ b/kolibri_explore_plugin/tasks.py
@@ -1,10 +1,24 @@
 from django.core.management import call_command
+from kolibri.core.content.tasks import get_status as get_content_task_status
+from kolibri.core.content.tasks import RemoteChannelResourcesImportValidator
+from kolibri.core.content.utils.paths import get_content_storage_remote_url
+from kolibri.core.content.utils.resource_import import (
+    RemoteChannelResourceImportManager,
+)
+from kolibri.core.content.utils.resource_import import (
+    RemoteChannelUpdateManager,
+)
+from kolibri.core.content.utils.resource_import import (
+    RemoteResourceImportManagerBase,
+)
 from kolibri.core.serializers import HexOnlyUUIDField
 from kolibri.core.tasks.decorators import register_task
 from kolibri.core.tasks.permissions import CanManageContent
 from kolibri.core.tasks.validation import JobValidator
 from rest_framework.serializers import CharField
 from rest_framework.serializers import ListField
+
+from .vendor.file_transfer import FileDownload
 
 QUEUE = "content"
 
@@ -35,3 +49,65 @@ class ExternalTagsJobValidator(JobValidator):
 )
 def applyexternaltags(node_id, tags=None):
     call_command("applyexternaltags", node_id, tags=tags)
+
+
+# Local remote resource import overrides to use vendored FileDownload.
+class ExploreRemoteResourceImportManagerBase(RemoteResourceImportManagerBase):
+    def create_file_transfer(self, f, filename, dest):
+        url = get_content_storage_remote_url(filename, baseurl=self.baseurl)
+        return FileDownload(
+            url,
+            dest,
+            f["id"],
+            session=self.session,
+            cancel_check=self.is_cancelled,
+            timeout=self.timeout,
+        )
+
+
+class ExploreRemoteChannelResourceImportManager(
+    ExploreRemoteResourceImportManagerBase, RemoteChannelResourceImportManager
+):
+    pass
+
+
+class ExploreRemoteChannelUpdateManager(
+    ExploreRemoteResourceImportManagerBase, RemoteChannelUpdateManager
+):
+    pass
+
+
+@register_task(
+    validator=RemoteChannelResourcesImportValidator,
+    track_progress=True,
+    cancellable=True,
+    permission_classes=[CanManageContent],
+    queue=QUEUE,
+    long_running=True,
+    status_fn=get_content_task_status,
+)
+def remotecontentimport(
+    channel_id,
+    baseurl=None,
+    peer_id=None,
+    node_ids=None,
+    exclude_node_ids=None,
+    update=False,
+    fail_on_error=False,
+    all_thumbnails=False,
+):
+    manager_class = (
+        ExploreRemoteChannelUpdateManager
+        if update
+        else ExploreRemoteChannelResourceImportManager
+    )
+    manager = manager_class(
+        channel_id,
+        baseurl=baseurl,
+        peer_id=peer_id,
+        node_ids=node_ids,
+        exclude_node_ids=exclude_node_ids,
+        fail_on_error=fail_on_error,
+        all_thumbnails=all_thumbnails,
+    )
+    manager.run()

--- a/kolibri_explore_plugin/vendor/file_transfer.py
+++ b/kolibri_explore_plugin/vendor/file_transfer.py
@@ -1,0 +1,443 @@
+import hashlib
+import logging
+import os
+import shutil
+from io import BufferedIOBase
+from time import sleep
+
+import requests
+from requests.exceptions import ChunkedEncodingError
+from requests.exceptions import ConnectionError
+from requests.exceptions import HTTPError
+from requests.exceptions import Timeout
+
+
+try:
+    import OpenSSL
+
+    SSLERROR = OpenSSL.SSL.Error
+except ImportError:
+    SSLERROR = requests.exceptions.SSLError
+
+
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
+
+
+RETRY_STATUS_CODE = [502, 503, 504, 521, 522, 523, 524]
+
+
+logger = logging.getLogger(__name__)
+
+
+class ExistingTransferInProgress(Exception):
+    pass
+
+
+class TransferNotYetCompleted(Exception):
+    pass
+
+
+class TransferCanceled(Exception):
+    pass
+
+
+class TransferNotYetClosed(Exception):
+    pass
+
+
+class TransferFailed(Exception):
+    pass
+
+
+def retry_import(e):
+    """
+    When an exception occurs during channel/content import, if
+        * there is an Internet connection error or timeout error,
+          or HTTPError where the error code is one of the RETRY_STATUS_CODE,
+          return return True to retry the file transfer
+    return value:
+        * True - needs retry.
+        * False - Does not need retry.
+    """
+
+    if (
+        isinstance(e, ConnectionError)
+        or isinstance(e, Timeout)
+        or isinstance(e, ChunkedEncodingError)
+        or (isinstance(e, HTTPError) and e.response.status_code in RETRY_STATUS_CODE)
+        or (isinstance(e, SSLERROR) and "decryption failed or bad record mac" in str(e))
+    ):
+        return True
+
+    return False
+
+
+class Transfer(object):
+    DEFAULT_TIMEOUT = 60
+
+    def __init__(
+        self,
+        source,
+        dest,
+        checksum=None,
+        block_size=2097152,
+        remove_existing_temp_file=True,
+        timeout=DEFAULT_TIMEOUT,
+        cancel_check=None,
+    ):
+        self.source = source
+        self.dest = dest
+        self.dest_tmp = dest + ".transfer"
+        self.checksum = checksum
+        self.block_size = block_size
+        self.timeout = timeout
+        self.started = False
+        self.completed = False
+        self.finalized = False
+        self.closed = False
+        if cancel_check and not callable(cancel_check):
+            raise AssertionError("cancel_check must be callable")
+        self._cancel_check = cancel_check
+
+        # TODO (aron): Instead of using signals, have bbq/iceqube add
+        # hooks that the app calls every so often to determine whether it
+        # should shut down or not.
+        # signal.signal(signal.SIGINT, self._kill_gracefully)
+        # signal.signal(signal.SIGTERM, self._kill_gracefully)
+
+        if os.path.isdir(dest):
+            raise AssertionError(
+                "dest must include the target filename, not just directory path"
+            )
+
+        # ensure the directories in the destination path exist
+        try:
+            filedir = os.path.dirname(self.dest)
+            os.makedirs(filedir)
+        except OSError as e:
+            if e.errno == 17:  # File exists (folder already created)
+                logger.debug(
+                    "Not creating directory '{}' as it already exists.".format(filedir)
+                )
+            else:
+                raise
+
+        if os.path.isfile(self.dest_tmp):
+            if remove_existing_temp_file:
+                try:
+                    os.remove(self.dest_tmp)
+                except OSError:
+                    pass
+            else:
+                raise ExistingTransferInProgress(
+                    "Temporary transfer destination '{}' already exists!".format(
+                        self.dest_tmp
+                    )
+                )
+
+        # record whether the destination file already exists, so it can be checked, but don't error out
+        self.dest_exists = os.path.isfile(dest)
+
+        self.hasher = hashlib.md5()
+
+    def start(self):
+        # open the destination file for writing
+        self.dest_file_obj = open(self.dest_tmp, "wb")
+
+    def cancel_check(self):
+        return self._cancel_check and self._cancel_check()
+
+    def _set_iterator(self):
+        if not hasattr(self, "_content_iterator"):
+            self._content_iterator = self._get_content_iterator()
+
+    def __next__(self):  # proxy this method to fully support Python 3
+        self._set_iterator()
+        return self.next()
+
+    def __iter__(self):
+        self._set_iterator()
+        return self
+
+    def _get_content_iterator(self):
+        raise NotImplementedError(
+            "Transfer subclass must implement a _get_content_iterator method"
+        )
+
+    def next(self):
+        try:
+            chunk = next(self._content_iterator)
+        except StopIteration:
+            self.completed = True
+            self.close()
+            self.finalize()
+            raise
+        self.dest_file_obj.write(chunk)
+        self.hasher.update(chunk)
+        return chunk
+
+    def _move_tmp_to_dest(self):
+        try:
+            shutil.move(self.dest_tmp, self.dest)
+        except FileNotFoundError as e:
+            if not os.path.exists(self.dest):
+                raise e
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, *exc_details):
+        if not self.closed:
+            self.close()
+        if not self.completed:
+            self.cancel()
+
+    def _kill_gracefully(self, *args, **kwargs):
+        self.cancel()
+        raise TransferCanceled("The transfer was canceled.")
+
+    def cancel(self):
+        self.close()
+        try:
+            os.remove(self.dest_tmp)
+        except OSError:
+            pass
+        self.canceled = True
+
+    def _checksum_correct(self):
+        return self.hasher.hexdigest() == self.checksum
+
+    def _verify_checksum(self):
+        # If checksum of the destination file is different from the localfile
+        # id indicated in the database, it means that the destination file
+        # is corrupted, either from origin or during import. Skip importing
+        # this file.
+        if self.checksum and not self._checksum_correct():
+            e = "File {} is corrupted.".format(self.source)
+            logger.error("An error occurred during content import: {}".format(e))
+            try:
+                os.remove(self.dest_tmp)
+            except OSError:
+                pass
+            raise TransferFailed(
+                "Transferred file checksums did not match for {}".format(self.source)
+            )
+
+    def finalize(self):
+        if not self.completed:
+            raise TransferNotYetCompleted(
+                "Transfer must have completed before it can be finalized."
+            )
+        if not self.closed:
+            raise TransferNotYetClosed(
+                "Transfer must be closed before it can be finalized."
+            )
+        if self.finalized:
+            return
+        self._verify_checksum()
+        self._move_tmp_to_dest()
+        self.finalized = True
+
+    def close(self):
+        self.dest_file_obj.close()
+        self.closed = True
+
+
+class FileDownload(Transfer):
+    def __init__(self, *args, **kwargs):
+
+        # allow an existing requests.Session instance to be passed in, so it can be reused for speed
+        if "session" in kwargs:
+            self.session = kwargs.pop("session")
+        else:
+            # initialize a fresh requests session, if one wasn't provided
+            self.session = requests.Session()
+
+        # Record the size of content that has been transferred
+        self.transferred_size = 0
+
+        super(FileDownload, self).__init__(*args, **kwargs)
+
+    def start(self):
+        super(FileDownload, self).start()
+        # initiate the download, check for status errors, and calculate download size
+        try:
+            self.response = self.session.get(
+                self.source, stream=True, timeout=self.timeout
+            )
+            self.response.raise_for_status()
+        except Exception as e:
+            retry = retry_import(e)
+            if not retry:
+                raise
+            # Catch exceptions to check if we should resume file downloading
+            self.resume()
+            if self.cancel_check():
+                self._kill_gracefully()
+
+        try:
+            self.total_size = int(self.response.headers["content-length"])
+        except KeyError:
+            # When a compressed file is saved on Google Cloud Storage,
+            # content-length is not available in the header,
+            # but we can use X-Goog-Stored-Content-Length.
+            gcs_content_length = self.response.headers.get(
+                "X-Goog-Stored-Content-Length"
+            )
+            if gcs_content_length:
+                self.total_size = int(gcs_content_length)
+            else:
+                # Get size of response content when file is compressed through nginx.
+                self.total_size = len(self.response.content)
+
+        self.started = True
+
+    def _get_content_iterator(self):
+        if not self.started:
+            raise AssertionError(
+                "File download must be started before it can be iterated."
+            )
+        return self.response.iter_content(self.block_size)
+
+    def next(self):
+        if self.cancel_check():
+            self._kill_gracefully()
+
+        try:
+            chunk = super(FileDownload, self).next()
+            self.transferred_size = self.transferred_size + len(chunk)
+            return chunk
+        except StopIteration:
+            raise
+        except Exception as e:
+            retry = retry_import(e)
+            if not retry:
+                raise
+            logger.error("Error reading download stream: {}".format(e))
+            self.resume()
+            return self.next()
+
+    def close(self):
+        if hasattr(self, "response"):
+            self.response.close()
+        super(FileDownload, self).close()
+
+    def resume(self):
+        logger.info("Waiting 30s before retrying import: {}".format(self.source))
+        for i in range(30):
+            if self.cancel_check():
+                logger.info("Canceling import: {}".format(self.source))
+                return
+            sleep(1)
+
+        try:
+
+            byte_range_resume = None
+            # When internet connection is lost at the beginning of start(),
+            # self.response does not get an assigned value
+            if hasattr(self, "response"):
+                # Use Accept-Ranges and Content-Length header to check if range
+                # requests are supported. For example, range requests are not
+                # supported on compressed files
+                byte_range_resume = self.response.headers.get(
+                    "accept-ranges", None
+                ) and self.response.headers.get("content-length", None)
+                resume_headers = self.response.request.headers
+
+                # Only use byte-range file resuming when sources support range requests
+                if byte_range_resume:
+                    range_headers = {"Range": "bytes={}-".format(self.transferred_size)}
+                    resume_headers.update(range_headers)
+
+                self.response = self.session.get(
+                    self.source,
+                    headers=resume_headers,
+                    stream=True,
+                    timeout=self.timeout,
+                )
+            else:
+                self.response = self.session.get(
+                    self.source, stream=True, timeout=self.timeout
+                )
+            self.response.raise_for_status()
+            self._content_iterator = self.response.iter_content(self.block_size)
+
+            # Remove the existing content in dest_file_object when range requests are not supported
+            if byte_range_resume is None:
+                self.dest_file_obj.seek(0)
+                self.dest_file_obj.truncate()
+                # Reset our ongoing file hash
+                self.hasher = hashlib.md5()
+        except Exception as e:
+            logger.error("Error reading download stream: {}".format(e))
+            retry = retry_import(e)
+            if not retry:
+                raise
+
+            self.resume()
+
+
+class FileCopy(Transfer):
+    def start(self):
+        if self.started:
+            raise AssertionError(
+                "File copy has already been started, and cannot be started again"
+            )
+        super(FileCopy, self).start()
+        self.total_size = os.path.getsize(self.source)
+        self.source_file_obj = open(self.source, "rb")
+        self.started = True
+
+    def _get_content_iterator(self):
+        while True:
+            if self.cancel_check():
+                self._kill_gracefully()
+            block = self.source_file_obj.read(self.block_size)
+            if not block:
+                break
+            yield block
+
+    def close(self):
+        self.source_file_obj.close()
+        super(FileCopy, self).close()
+
+
+class RemoteFile(BufferedIOBase):
+    """
+    A file like wrapper to handle downloading a file from a remote location.
+    """
+
+    def __init__(self, filepath, remote_url, callback=None):
+        self.transfer = FileDownload(
+            remote_url, filepath, remove_existing_temp_file=True
+        )
+        self.callback = callback
+        self.transfer.start()
+        self._previously_read = b""
+
+    def read(self, size=-1):
+        data = self._previously_read
+        while size == -1 or len(data) < size:
+            try:
+                data += next(self.transfer)
+            except StopIteration:
+                if self.callback:
+                    self.callback()
+                break
+        if size != -1:
+            self._previously_read = data[size:]
+            data = data[:size]
+        return data
+
+    def close(self):
+        # Finish the download and close the file
+        self.read()
+        self.transfer.close()
+
+    def seek(self, offset, whence=0):
+        # Just read from the response until the offset is reached
+        self.read(size=offset)

--- a/kolibri_explore_plugin/vendor/file_transfer.py
+++ b/kolibri_explore_plugin/vendor/file_transfer.py
@@ -262,6 +262,10 @@ class FileDownload(Transfer):
 
         super(FileDownload, self).__init__(*args, **kwargs)
 
+    @property
+    def transfer_size(self):
+        return self.total_size
+
     def start(self):
         super(FileDownload, self).start()
         # initiate the download, check for status errors, and calculate download size

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,5 +14,6 @@ exclude = '''
   | static
   | dist
   | node_modules
+  | kolibri_explore_plugin/vendor
 )/
 '''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ exclude = '''
   | _build
   | buck-out
   | build
+  | static
   | dist
+  | node_modules
 )/
 '''


### PR DESCRIPTION
Since 0.16.0-alpha13, Kolibri's `FileDownload` class uses HTTP range requests to move towards resumable downloads. This significantly slows down network throughput for large downloads as it requires many serial requests to retrieve a single file. Upstream has been made aware and will presumably fix the regression.

In the meantime, this vendors the `FileDownload` code from 0.16.0-alpha12 and adds the necessary plumbing to use it. Comparing the `FileDownload` implementation with the inventor pack, I measured the following timings for the initial content pack download:

Upstream FileDownload:
Start 14:15:18,457
End 14:22:32,008
Total 7m14s

0.16.0-alpha12 FileDownload:
Start 14:09:19,618
End 14:12:01,681
Total 2m42s

#627