### PR TITLE
Download: Fix error downloading thumbnails

### DIFF
--- a/kolibri_explore_plugin/collectionviews.py
+++ b/kolibri_explore_plugin/collectionviews.py
@@ -196,7 +196,7 @@ class EndlessKeyContentManifest(ContentManifest):
         tasks = []
 
         for channel_id in _get_channel_ids_for_all_content_manifests():
-            channel_metadata = self._get_channel_metadata(channel_id)
+            channel_metadata = _get_channel_metadata(channel_id)
             tasks.append(
                 {
                     "task": "remotecontentimport",


### PR DESCRIPTION
In a previous change, the `_get_channel_metadata` function was moved outside `EndlessKeyContentManifest`. However, this was not corrected in `get_contentthumbnail_tasks`.

https://github.com/endlessm/kolibri-explore-plugin/issues/648