### PR TITLE
footer: Add app install links for Play and Microsoft stores

### DIFF
--- a/kolibri_explore_plugin/assets/src/app.js
+++ b/kolibri_explore_plugin/assets/src/app.js
@@ -14,6 +14,7 @@ Vue.use(BootstrapVue);
 Vue.use(IconsPlugin);
 
 Vue.config.productionTip = false;
+Vue.config.ignoredElements = ['ms-store-badge'];
 
 Vue.use(EkComponents);
 

--- a/kolibri_explore_plugin/assets/src/components/AboutFooter.vue
+++ b/kolibri_explore_plugin/assets/src/components/AboutFooter.vue
@@ -2,25 +2,65 @@
 
   <b-container class="mb-5">
 
-    <b-row class="d-flex justify-content-center" cols="3">
+    <b-row
+      :class="{
+        'd-flex': true,
+        'justify-content-between': showStoreButtons,
+        'justify-content-around': !showStoreButtons,
+      }"
+    >
 
-      <b-col class="col-auto d-flex justify-content-center">
-        <button
-          v-b-modal.about-modal
-          class="btn d-md-block d-none shadow-none"
-        >
-          {{ $tr('aboutLabel') }}
-        </button>
+      <b-col class="col-auto d-flex justify-content-start">
+        <b-container class="h-100" fillHeight>
+          <b-row class="d-flex h-100 justify-content-center">
+
+            <b-col class="col-auto d-flex justify-content-start">
+              <button
+                v-b-modal.about-modal
+                class="btn d-md-block d-none shadow-none"
+              >
+                {{ $tr('aboutLabel') }}
+              </button>
+            </b-col>
+
+            <b-col class="col-auto d-flex justify-content-end">
+              <button
+                v-b-modal.about-modal
+                class="btn d-md-block d-none shadow-none"
+                @click="$root.$emit('setAboutSection', 'privacy-policy-link')"
+              >
+                {{ $tr('privacyPolicyLabel') }}
+              </button>
+            </b-col>
+
+          </b-row>
+        </b-container>
       </b-col>
 
-      <b-col class="col-auto d-flex justify-content-center">
-        <button
-          v-b-modal.about-modal
-          class="btn d-md-block d-none shadow-none"
-          @click="$root.$emit('setAboutSection', 'privacy-policy-link')"
-        >
-          {{ $tr('privacyPolicyLabel') }}
-        </button>
+      <b-col v-if="showStoreButtons" class="col-auto d-flex justify-content-end">
+        <b-container class="h-100" fillHeight>
+          <b-row class="d-flex h-100 justify-content-center">
+
+            <b-col class="col-auto d-flex justify-content-start">
+              <a
+                :href="googleStoreUrl"
+                target="_blank"
+                class="google-play-button"
+              >
+                <img :src="googlePlayImage" :alt="$tr('getOnGooglePlay')">
+              </a>
+            </b-col>
+
+            <b-col class="col-auto d-flex justify-content-end">
+              <script type="module" src="https://get.microsoft.com/badge/ms-store-badge.bundled.js"></script>
+              <ms-store-badge
+                :productid="windowsApplicationId"
+                cid="ek-online"
+              />
+            </b-col>
+
+          </b-row>
+        </b-container>
       </b-col>
 
     </b-row>
@@ -32,12 +72,55 @@
 
 <script>
 
+  import { currentLanguage } from 'kolibri.utils.i18n';
+  import plugin_data from 'plugin_data';
+
   export default {
     name: 'AboutFooter',
+    computed: {
+      googlePlayImage() {
+        return `https://play.google.com/intl/en_us/badges/static/images/badges/${encodeURIComponent(
+          currentLanguage
+        )}_badge_web_generic.png`;
+      },
+      googleStoreUrl() {
+        return `https://play.google.com/store/apps/details?id=${encodeURIComponent(
+          plugin_data.androidApplicationId
+        )}&referrer=utm_source%3dek-online`;
+      },
+      windowsApplicationId() {
+        return plugin_data.windowsApplicationId;
+      },
+      showStoreButtons() {
+        return plugin_data.androidApplicationId != '' && plugin_data.windowsApplicationId != '';
+      },
+    },
     $trs: {
       aboutLabel: 'About Endless Key',
       privacyPolicyLabel: 'Privacy Policy',
+      getOnGooglePlay: 'Get it on Google Play',
     },
   };
 
 </script>
+
+
+<style lang="scss" scoped>
+
+  @import '../styles';
+
+  /* The Google image comes with an unhelpful 1/4 height transparent border all
+   * the way round, whereas the Microsoft one has no border. Play all sorts of
+   * bespoke sizing games to get them to match. */
+  .google-play-button img {
+    max-width: 200px;
+    max-height: 60px;
+  }
+
+  ms-store-badge::part(img) {
+    max-width: 200px;
+    max-height: 40px;
+    margin: 10px 0;
+  }
+
+</style>

--- a/kolibri_explore_plugin/kolibri_plugin.py
+++ b/kolibri_explore_plugin/kolibri_plugin.py
@@ -46,7 +46,7 @@ class ExploreAsset(webpack_hooks.WebpackBundleHook):
 
     @property
     def plugin_data(self):
-        return {
+        options = {
             "showAsStandaloneChannel": conf.OPTIONS["Explore"][
                 "SHOW_AS_STANDALONE_CHANNEL"
             ],
@@ -57,6 +57,19 @@ class ExploreAsset(webpack_hooks.WebpackBundleHook):
             "hideDiscoveryTab": conf.OPTIONS["Explore"]["HIDE_DISCOVERY_TAB"],
             "feedbackUrl": conf.OPTIONS["Explore"]["FEEDBACK_URL"],
         }
+        if "Pwa" in conf.OPTIONS:
+            pwa_options = {
+                # Use the app IDs from the PWA plugin, which advertises them as
+                # related applications.
+                "androidApplicationId": conf.OPTIONS["Pwa"][
+                    "ANDROID_APPLICATION_ID"
+                ],
+                "windowsApplicationId": conf.OPTIONS["Pwa"][
+                    "WINDOWS_APPLICATION_ID"
+                ],
+            }
+            options.update(pwa_options)
+        return options
 
 
 @register_hook


### PR DESCRIPTION
These will allow the user to install the Endless Key app, if that would be a better fit for them on their device than using key.endlessos.org in a browser.

The badges came from:
 - https://play.google.com/intl/en_us/badges/
 - https://apps.microsoft.com/store/app-badge

Getting them the same size was a complete pain because, for no good reason, Google have baked a transparent border into the image they serve to you. We have to use the image they serve because otherwise we’d have to carry 20 different localised versions.

Changing the layout to match the design
(https://github.com/endlessm/endless-key-content-private/issues/64#issuecomment-1592442043) required splitting the footer bar into two separate containers, to allow for grouping the links/buttons at the start and end of the footer row.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

https://github.com/endlessm/endless-key-content-private/issues/64