### PR TITLE
CI: Fix version substitution in endless-key-app trigger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -142,6 +142,6 @@ jobs:
               repo: "endless-key-app",
               event_type: "kolibri-explore-plugin-release",
               client_payload: {
-                VERSION: "$VERSION",
+                VERSION: "${{ env.VERSION }}",
               }
             })


### PR DESCRIPTION
The node script passed to the `github_script` action needs to have the `VERSION` value derived from the `env` context rather than expecting it to be resolved like a shell variable.

https://phabricator.endlessm.com/T34806