### PR TITLE
footer: Use Native App Install Prompt to install Android app

### DIFF
--- a/kolibri_explore_plugin/assets/src/components/AboutFooter.vue
+++ b/kolibri_explore_plugin/assets/src/components/AboutFooter.vue
@@ -113,7 +113,7 @@
     },
     methods: {
       beforeInstallPrompt(e) {
-        console.debug("beforeInstallPrompt called to provide deferred Play Store prompt");
+        console.debug('beforeInstallPrompt called to provide deferred Play Store prompt');
 
         // Prevent Chrome 67 and earlier from automatically showing the prompt
         e.preventDefault();
@@ -121,7 +121,7 @@
         this.deferredInstallPrompt = e;
       },
       installFromPlayStore(e) {
-        console.debug("Prompting to install app from Play Store");
+        console.debug('Prompting to install app from Play Store');
 
         if (!this.deferredInstallPrompt) return;
 

--- a/kolibri_explore_plugin/assets/src/components/AboutFooter.vue
+++ b/kolibri_explore_plugin/assets/src/components/AboutFooter.vue
@@ -104,13 +104,13 @@
         return plugin_data.androidApplicationId != '' && plugin_data.windowsApplicationId != '';
       },
     },
-    created() {
+    mounted() {
       // Add a listener for Chrome, to support an in-browser prompt to install
       // the Android app.
       // See https://developer.chrome.com/blog/app-install-banners-native/.
       window.addEventListener('beforeinstallprompt', this.beforeInstallPrompt);
     },
-    destroyed() {
+    beforeDestroy() {
       window.removeEventListener('beforeinstallprompt', this.beforeInstallPrompt);
       this.deferredInstallPrompt = null;
     },

--- a/kolibri_explore_plugin/assets/src/components/AboutFooter.vue
+++ b/kolibri_explore_plugin/assets/src/components/AboutFooter.vue
@@ -74,7 +74,10 @@
 <script>
 
   import { currentLanguage } from 'kolibri.utils.i18n';
+  import logger from 'kolibri.lib.logging';
   import plugin_data from 'plugin_data';
+
+  const logging = logger.getLogger(__filename);
 
   export default {
     name: 'AboutFooter',
@@ -113,7 +116,7 @@
     },
     methods: {
       beforeInstallPrompt(e) {
-        console.debug('beforeInstallPrompt called to provide deferred Play Store prompt');
+        logging.debug('beforeInstallPrompt called to provide deferred Play Store prompt');
 
         // Prevent Chrome 67 and earlier from automatically showing the prompt
         e.preventDefault();
@@ -121,7 +124,7 @@
         this.deferredInstallPrompt = e;
       },
       installFromPlayStore(e) {
-        console.debug('Prompting to install app from Play Store');
+        logging.debug('Prompting to install app from Play Store');
 
         if (!this.deferredInstallPrompt) return;
 
@@ -132,9 +135,9 @@
         // Wait for the user to respond to the prompt
         this.deferredInstallPrompt.userChoice.then(choiceResult => {
           if (choiceResult.outcome === 'accepted') {
-            console.log('User accepted the A2HS prompt');
+            logging.log('User accepted the app install prompt');
           } else {
-            console.log('User dismissed the A2HS prompt');
+            logging.log('User dismissed the app install prompt');
           }
           this.deferredInstallPrompt = null;
         });


### PR DESCRIPTION
When supported, use this API to provide a slightly more streamlined experience for installing the Android app when pressing the “Get it on Google Play” button.

The API is only supported by Chrome, on mobile, if the app is advertised as a related application in the PWA manifest for the site, and if the app is not already installed.

The full list of requirements are here:
https://developer.chrome.com/blog/app-install-banners-native/#what-are-the-criteria

If the API is not supported, the button will function as a link as normal.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

https://github.com/endlessm/endless-key-content-private/issues/64