### PR TITLE
footer: Correctly hide store buttons in apps

### DIFF
--- a/kolibri_explore_plugin/assets/src/components/AboutFooter.vue
+++ b/kolibri_explore_plugin/assets/src/components/AboutFooter.vue
@@ -92,7 +92,7 @@
         return plugin_data.windowsApplicationId;
       },
       showStoreButtons() {
-        return plugin_data.androidApplicationId != '' && plugin_data.windowsApplicationId != '';
+        return !!plugin_data.androidApplicationId && !!plugin_data.windowsApplicationId;
       },
     },
     $trs: {


### PR DESCRIPTION
showStoreButtons is meant to be true only if both the
androidApplicationId and windowsApplicationId are defined. However the
test was implemented as comparing them to empty string. When they are
not defined, they take the value `undefined` which is not equal to empty
string. As a result, the Google Play and Microsoft Store buttons are
shown in the Android app (and probably also in the Windows app).

Instead, use double-negation to treat both empty string and undefined as
false, and a non-empty string as true.

    > !!undefined
    false
    > !!''
    false
    > !!"org.endlessos.Key"
    true
