### PR TITLE
Add title attribute for clamped text

### DIFF
--- a/packages/ek-components/src/components/EkCardBody.vue
+++ b/packages/ek-components/src/components/EkCardBody.vue
@@ -21,6 +21,7 @@
         <VClamp
           autoresize
           :maxLines="titleLines"
+          :title="node.title"
         >
           {{ node.title }}
         </VClamp>
@@ -33,6 +34,7 @@
         <VClamp
           autoresize
           :maxLines="3"
+          :title="subtitle"
         >
           {{ subtitle }}
         </VClamp>

--- a/packages/ek-components/src/components/EkCarouselCardTitle.vue
+++ b/packages/ek-components/src/components/EkCarouselCardTitle.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <component :is="tag">
-      <VClamp autoresize :maxLines="lines">
+      <VClamp autoresize :maxLines="lines" :title="node.title">
         {{ node.title }}
       </VClamp>
     </component>
@@ -9,7 +9,7 @@
       v-if="showDescription"
       class="align-self-center d-none d-sm-block mb-1 subtitle text-muted"
     >
-      <VClamp autoresize :maxLines="descriptionLines">
+      <VClamp autoresize :maxLines="descriptionLines" :title="subtitle">
         {{ subtitle }}
       </VClamp>
     </p>

--- a/packages/ek-components/src/components/EkChannelCard.vue
+++ b/packages/ek-components/src/components/EkChannelCard.vue
@@ -18,6 +18,7 @@
       <VClamp
         autoresize
         :maxLines="maxDescriptionLines"
+        :title="description"
       >
         {{ description }}
       </VClamp>

--- a/packages/ek-components/src/components/EkTopicCard.vue
+++ b/packages/ek-components/src/components/EkTopicCard.vue
@@ -24,6 +24,7 @@
               <VClamp
                 autoresize
                 :maxLines="titleMaxLines"
+                :title="node.title"
               >
                 {{ node.title }}
               </VClamp>
@@ -32,6 +33,7 @@
               <VClamp
                 autoresize
                 :maxLines="descriptionMaxLines"
+                :title="node.description"
               >
                 {{ node.description }}
               </VClamp>


### PR DESCRIPTION
For text that may be ellipsized, include a "title" attribute with the full text so it appears as a tooltip in most web browsers.