### PR TITLE
PackSelection: Reinstate white background

### DIFF
--- a/packages/welcome-screen/src/views/PackSelection.vue
+++ b/packages/welcome-screen/src/views/PackSelection.vue
@@ -7,6 +7,7 @@
           v-slot="slotProps"
           class="mb-3"
           :nodes="PackMetadata"
+          :hasWhiteBackground="true"
           :itemsPerSlide="{ lg: 3, md: 2, sm: 1 }"
         >
           <template


### PR DESCRIPTION
PackSelection has an EkSlidableGrid, not an EkChannelCard, so removing the 'hasWhiteBackground' property was a mistake.

Reinstate that.