### PR TITLE
Add labels for missing media types

### DIFF
--- a/packages/ek-components/src/components/EkPlayButton.vue
+++ b/packages/ek-components/src/components/EkPlayButton.vue
@@ -77,6 +77,9 @@ export default {
           return 'ExerciseIcon';
         case 'html5':
         case 'zim':
+        case 'slideshow':
+        case 'h5p':
+        case 'quiz':
           return 'Html5Icon';
         case 'bundle':
           return 'BundleIcon';

--- a/packages/ek-components/src/components/EkPlayButton.vue
+++ b/packages/ek-components/src/components/EkPlayButton.vue
@@ -100,7 +100,7 @@ export default {
       if (this.label) {
         return this.label;
       }
-      return MediaTypeVerbs[this.kind];
+      return MediaTypeVerbs[this.kind] ?? MediaTypeVerbs['video'];
     },
   },
 };

--- a/packages/ek-components/src/constants.js
+++ b/packages/ek-components/src/constants.js
@@ -6,6 +6,9 @@ export const MediaTypeVerbs = {
   'exercise': 'Practice',
   'html5': 'Interact',
   'zim': 'Interact',
+  'slideshow': 'Interact',
+  'h5p': 'Interact',
+  'quiz': 'Interact',
 };
 
 export const MediaFilterName = 'Learning activity';


### PR DESCRIPTION
Adapt to mediatypes missing from Kolibri like 'h5p'.

Resolves #560