### PR TITLE
Discovery page: Allow unavailable featured channels

### DIFF
--- a/kolibri_explore_plugin/assets/src/views/DiscoveryPageContenPacks.vue
+++ b/kolibri_explore_plugin/assets/src/views/DiscoveryPageContenPacks.vue
@@ -137,6 +137,7 @@
 
         const featuredPromise = ContentNodeExtrasResource.fetchByExternalTag('featured-channel', {
           only_root_nodes: true,
+          no_available_filtering: true,
         }).then(({ data }) => {
           const nodes = data.map(n => {
             n.bigThumbnail = getBigThumbnail(n);


### PR DESCRIPTION
The featured channels in the collection may be unavailable because the collection is not importing any content from them. Still they should appear in the Featured row.