### PR TITLE
EkPlayButton: Don’t use nullish coalescing operator

### DIFF
--- a/packages/ek-components/src/components/EkPlayButton.vue
+++ b/packages/ek-components/src/components/EkPlayButton.vue
@@ -100,7 +100,7 @@ export default {
       if (this.label) {
         return this.label;
       }
-      return MediaTypeVerbs[this.kind] ?? MediaTypeVerbs['video'];
+      return (MediaTypeVerbs[this.kind] !== null && MediaTypeVerbs[this.kind] !== undefined) ? MediaTypeVerbs[this.kind] : MediaTypeVerbs['video'];
     },
   },
 };


### PR DESCRIPTION
My ChromeOS test machine has Android WebView 68, which doesn’t support this operator. That causes a syntax error when loading the kolibri-explore-plugin, and hence the app never loads.

Nowhere else in the code is the nullish coalescing operator used, so let’s get rid of this instance for now.

It’s apparently supported by WebView 80 onwards
(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing#browser_compatibility). I don’t know if we want to depend on that yet.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

Helps: #156