### PR TITLE
MainSections: Center pill text

### DIFF
--- a/packages/template-ui/src/components/MainSections.vue
+++ b/packages/template-ui/src/components/MainSections.vue
@@ -39,4 +39,14 @@ export default {
 
 <style lang="scss" scoped>
 @import '@/styles.scss';
+
+/*
+ * This ensures the text of the pills are vertically centered. This
+ * is not generalizable to other pill-like buttons.
+ */
+a.btn.rounded-pill {
+  display: flex;
+  align-self: baseline;
+}
+
 </style>


### PR DESCRIPTION
This is mostly a workaround to how Bootstrap styles pill-like buttons by default. It only applies to the pills at channel views, which are the most visible ones.

https://github.com/endlessm/kolibri-explore-plugin/issues/694

---

| Comparison |
|---|
| Before: |
| ![image](https://github.com/endlessm/kolibri-explore-plugin/assets/3518204/a2ef221c-1a4d-4f54-864d-7df1f86acd4c) |
| After |
| ![image](https://github.com/endlessm/kolibri-explore-plugin/assets/3518204/33aa3a4f-fd3b-45ce-a8ba-68bf45e7ac05) |

