### PR TITLE
Disable content caching

### DIFF
--- a/kolibri_explore_plugin/api_urls.py
+++ b/kolibri_explore_plugin/api_urls.py
@@ -11,11 +11,19 @@ from .collectionviews import resume_download
 from .collectionviews import start_download
 from .collectionviews import update_download
 from .viewsets import ContentNodeExtrasViewset
+from .viewsets import ExploreChannelMetadataViewSet
+from .viewsets import ExploreContentNodeViewset
 from .viewsets import ExternalContentTagViewset
 
 
 router = routers.SimpleRouter()
 
+router.register(r"channel", ExploreChannelMetadataViewSet, basename="channel")
+router.register(
+    r"contentnode",
+    ExploreContentNodeViewset,
+    basename="contentnode",
+)
 router.register(
     r"externalcontenttag",
     ExternalContentTagViewset,

--- a/kolibri_explore_plugin/assets/src/apiResources.js
+++ b/kolibri_explore_plugin/assets/src/apiResources.js
@@ -1,4 +1,22 @@
 import { Resource } from 'kolibri.lib.apiResource';
+import {
+  ChannelResource as _ChannelResource,
+  ContentNodeResource as _ContentNodeResource,
+} from 'kolibri.resources';
+
+export const ChannelResource = Object.create(_ChannelResource);
+// Use the explore API endpoint.
+ChannelResource.name = 'kolibri:kolibri_explore_plugin:channel';
+// Restore the standard Resource client that doesn't add the
+// contentCacheKey query parameter.
+ChannelResource.client = Resource.prototype.client;
+
+export const ContentNodeResource = Object.create(_ContentNodeResource);
+// Use the explore API endpoint.
+ContentNodeResource.name = 'kolibri:kolibri_explore_plugin:contentnode';
+// Restore the standard Resource client that doesn't add the
+// contentCacheKey query parameter.
+ContentNodeResource.client = Resource.prototype.client;
 
 export const ExternalContentTagResource = new Resource({
   name: 'externalcontenttag',

--- a/kolibri_explore_plugin/assets/src/kolibriApi.js
+++ b/kolibri_explore_plugin/assets/src/kolibriApi.js
@@ -1,11 +1,12 @@
 import urls from 'kolibri.urls';
-import { ChannelResource, ContentNodeResource, ContentNodeSearchResource } from 'kolibri.resources';
+import { ContentNodeSearchResource } from 'kolibri.resources';
 
 import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
 
 import router from 'kolibri.coreVue.router';
 import store from 'kolibri.coreVue.vuex.store';
 import { utils } from 'ek-components';
+import { ChannelResource, ContentNodeResource } from './apiResources';
 import { showTopicsContentInLightbox } from './modules/topicsTree/handlers';
 import { PageNames } from './constants';
 import { getChannelIcon } from './customApps';

--- a/kolibri_explore_plugin/assets/src/modules/coreExplore/actions.js
+++ b/kolibri_explore_plugin/assets/src/modules/coreExplore/actions.js
@@ -1,4 +1,4 @@
-import { ChannelResource } from 'kolibri.resources';
+import { ChannelResource } from '../../apiResources';
 import { pageNameToModuleMap } from '../../constants';
 
 export function resetModuleState(store, lastPageName) {

--- a/kolibri_explore_plugin/assets/src/modules/topicsRoot/handlers.js
+++ b/kolibri_explore_plugin/assets/src/modules/topicsRoot/handlers.js
@@ -3,9 +3,10 @@ import urls from 'kolibri.urls';
 import { utils } from 'ek-components';
 import router from 'kolibri.coreVue.router';
 import plugin_data from 'plugin_data';
-import { ChannelResource, ContentNodeResource, ContentNodeSearchResource } from 'kolibri.resources';
+import { ContentNodeSearchResource } from 'kolibri.resources';
 import { getContentNodeThumbnail } from 'kolibri.utils.contentNode';
 
+import { ChannelResource, ContentNodeResource } from '../../apiResources';
 import { CarouselItemsLength, SEARCH_MAX_RESULTS, PageNames } from '../../constants';
 import { CustomChannelApps, getBigThumbnail, getChannelIcon } from '../../customApps';
 import {

--- a/kolibri_explore_plugin/assets/src/views/ContentPage.vue
+++ b/kolibri_explore_plugin/assets/src/views/ContentPage.vue
@@ -10,7 +10,7 @@
 <script>
 
   import { mapState } from 'vuex';
-  import { ContentNodeResource } from 'kolibri.resources';
+  import { ContentNodeResource } from '../apiResources';
   import ContentItem from './ContentItem';
 
   export default {

--- a/kolibri_explore_plugin/assets/src/views/SearchPage.vue
+++ b/kolibri_explore_plugin/assets/src/views/SearchPage.vue
@@ -124,8 +124,8 @@
   import _ from 'lodash';
   import { mapMutations, mapState } from 'vuex';
   import { utils, constants, responsiveMixin } from 'ek-components';
-  import { ContentNodeResource } from 'kolibri.resources';
 
+  import { ContentNodeResource } from '../apiResources';
   import { searchChannelsOnce } from '../modules/topicsRoot/handlers';
   import navigationMixin from '../mixins/navigationMixin';
 

--- a/kolibri_explore_plugin/viewsets.py
+++ b/kolibri_explore_plugin/viewsets.py
@@ -1,5 +1,10 @@
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_control
+from django.views.decorators.http import etag
 from kolibri.core.api import ReadOnlyValuesViewset
+from kolibri.core.content.api import ChannelMetadataViewSet
 from kolibri.core.content.api import ContentNodeViewset
+from kolibri.core.content.api import get_cache_key
 from kolibri.core.content.models import ContentNode
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -7,12 +12,33 @@ from rest_framework.response import Response
 from .models import ContentNodeExtras
 from .models import ExternalContentTag
 
+cache_key_etag_decorators = (
+    etag(get_cache_key),
+    cache_control(no_cache=True),
+)
+
 
 class ExternalContentTagViewset(ReadOnlyValuesViewset):
     values = ("id", "tag_name")
 
     def get_queryset(self):
         return ExternalContentTag.objects.all()
+
+
+@method_decorator(cache_key_etag_decorators, name="dispatch")
+class ExploreChannelMetadataViewSet(ChannelMetadataViewSet):
+    # Override the dispatch method so that the metadata_cache decorated
+    # dispatch from ChannelMetadataViewSet isn't used.
+    def dispatch(self, *args, **kwargs):
+        return ReadOnlyValuesViewset.dispatch(self, *args, **kwargs)
+
+
+@method_decorator(cache_key_etag_decorators, name="dispatch")
+class ExploreContentNodeViewset(ContentNodeViewset):
+    # Override the dispatch method so that the metadata_cache decorated
+    # dispatch from ContentNodeViewset isn't used.
+    def dispatch(self, *args, **kwargs):
+        return ReadOnlyValuesViewset.dispatch(self, *args, **kwargs)
 
 
 class ContentNodeExtrasViewset(ContentNodeViewset):


### PR DESCRIPTION
Add custom content API endpoints that don't use caching in the browser or server to ensure that fresh content is always returned. The content cache key as `ETag` is preserved so that the server can still return early when the browser includes the current content cache key in an `If-None-Match` header. I'm sure I'm "doing it wrong" in JS.

The last commit fixes a minor issue where upstream's channel import tasks don't update the content cache key if the channel doesn't have any nodes. See https://github.com/learningequality/kolibri/pull/10899.

I'm marking this as a draft since the commits need a bit of polish and probably more testing, but in some light testing it seems to fix the stale cached content data issues we've been hitting.

Fixes: #687