### PR TITLE
ci: Add --ci argument to bootstrap.sh and use it from CI jobs

### DIFF
--- a/.github/workflows/bump2release.yml
+++ b/.github/workflows/bump2release.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install dependencies in pipenv
         run: |
-          sh ./scripts/bootstrap.sh
+          sh ./scripts/bootstrap.sh --ci
 
       - name: Bump minor version
         if: ${{ inputs.MAJOR_OR_MINOR != 'major' }}

--- a/.github/workflows/bump2release.yml
+++ b/.github/workflows/bump2release.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install dependencies in pipenv
         run: |
-          sh ./scripts/bootstrap.sh --ci
+          bash ./scripts/bootstrap.sh --ci
 
       - name: Bump minor version
         if: ${{ inputs.MAJOR_OR_MINOR != 'major' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Install dependencies in pipenv
         run: |
-          sh ./scripts/bootstrap.sh --ci
+          bash ./scripts/bootstrap.sh --ci
 
       - name: Build
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Install dependencies in pipenv
         run: |
-          sh ./scripts/bootstrap.sh
+          sh ./scripts/bootstrap.sh --ci
 
       - name: Build
         run: |

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install dependencies
       if: steps.cache-pipenv.outputs.cache-hit != 'true'
       run: |
-        pipenv install --dev
+        pipenv install --dev --ignore-pipfile
 
     - name: Set up Node
       uses: actions/setup-node@v3

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -2,7 +2,29 @@
 #
 # Setup Project
 
-pipenv install --dev --deploy
+# Argument parsing
+pipenv_install_args=
+
+while :; do
+  case $1 in
+    --ci)
+      # Prevent the Pipfile.lock from being updated automatically. Just use
+      # the pinned dependencies.
+      pipenv_install_args=( "--ignore-pipfile" )
+      ;;
+    -h|-\?|--help|-?*)
+      echo "Usage: bootstrap.sh [--ci]" >&2
+      exit
+      ;;
+    *)
+      break
+  esac
+
+  shift
+done
+
+# Install things
+pipenv install --dev --deploy "${pipenv_install_args[@]}"
 pipenv run nodeenv -p --node=16.14.0
 pipenv run npm install -g yarn@1.22.19
 pipenv run yarn global add @vue/cli@v4.5.15


### PR DESCRIPTION
Passing `--ci` will cause `--ignore-pipfile` to be passed to `pipenv install`, which will cause it to only use the `Pipfile.lock` for installing dependencies, and not install the latest versions which match `Pipfile`, or to update the `Pipfile.lock`. This means that the dependency versions used in CI are properly pinned, and hence we’re not testing them as well as whatever changes are in the associated PR at the same time.

`bootstrap.sh` unfortunately can’t be used from `node.yml` because it benefits from using `actions/setup-node` to cache the node installation.

Prompted by https://github.com/endlessm/kolibri-explore-plugin/pull/701