### PR TITLE
build: Include all the yarn-built app files in the dist wheel

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 # webpack build-info is needed at runtime, but it’s only built at build time
-# by yarn, so setuptools doesn’t know about it.
+# by yarn, so setuptools doesn’t know about it. Similarly for the compiled app.
 include kolibri_explore_plugin/static/build-info.json
+recursive-include kolibri_explore_plugin/static/kolibri_explore_plugin.app *
 
 # build/kolibri_explore_plugin.app_stats.json is needed by Kolibri at runtime,
 # but it is created at build time.


### PR DESCRIPTION
These were mistakenly omitted from commit
bf95c0021f55262c6196c052fcba78e9e945f567.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

Fixes: #703