### PR TITLE
Channel override: adjust representation for the removal of bundles

### DIFF
--- a/packages/template-ui/channel-overrides/ted-ed-lessons/options.json
+++ b/packages/template-ui/channel-overrides/ted-ed-lessons/options.json
@@ -1,4 +1,0 @@
-{
-  "carouselKinds": ["video"],
-  "bundleKind": "simple"
-}


### PR DESCRIPTION
We simplified the TED-Ed channel to not have bundles anymore, just the videos. Remove the bundle specific custom presentation.

https://github.com/endlessm/kolibri-explore-plugin/issues/730