### PR TITLE
Fix bootstrap arguments passed to pipenv

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -3,14 +3,14 @@
 # Setup Project
 
 # Argument parsing
-pipenv_install_args=
+pipenv_install_args=()
 
 while :; do
   case $1 in
     --ci)
       # Prevent the Pipfile.lock from being updated automatically. Just use
       # the pinned dependencies.
-      pipenv_install_args=( "--ignore-pipfile" )
+      pipenv_install_args+=( "--ignore-pipfile" )
       ;;
     -h|-\?|--help|-?*)
       echo "Usage: bootstrap.sh [--ci]" >&2


### PR DESCRIPTION
If you don't specify any options to bootstrap.sh, `pipenv_install_args` will retain its default of an empty string and pipenv will be passed an empty quoted argument. That's wrong and some versions of pipenv fail expecting the argument to be a package requirement.

Instead, initialize the variable as an array and append to it as needed. Bash expands an empty array to nothing using the `"${var[@]}"` notation.