### PR TITLE
Override remotecontentimport task priority to high

### DIFF
--- a/kolibri_explore_plugin/assets/src/modules/manageContent/handlers.js
+++ b/kolibri_explore_plugin/assets/src/modules/manageContent/handlers.js
@@ -1,4 +1,4 @@
-import { TaskStatuses, TaskTypes } from 'kolibri.utils.syncTaskUtils';
+import { TaskStatuses } from 'kolibri.utils.syncTaskUtils';
 import { constants } from 'ek-components';
 import { TaskResource } from 'kolibri.resources';
 import store from 'kolibri.coreVue.vuex.store';
@@ -48,7 +48,7 @@ export function startContentDownload(channelId, contentId) {
     channel_id: channelId,
     channel_name: 'foo',
     node_ids: [contentId],
-    type: TaskTypes.REMOTECONTENTIMPORT,
+    type: 'kolibri_explore_plugin.tasks.remotecontentimport',
   };
 
   return TaskResource.startTask(taskParams)

--- a/kolibri_explore_plugin/collectionviews.py
+++ b/kolibri_explore_plugin/collectionviews.py
@@ -8,7 +8,6 @@ from django.utils.translation import gettext_lazy as _
 from kolibri.core.content.errors import InsufficientStorageSpaceError
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.tasks import remotechannelimport
-from kolibri.core.content.tasks import remotecontentimport
 from kolibri.core.content.utils.content_manifest import ContentManifest
 from kolibri.core.content.utils.content_manifest import (
     ContentManifestParseError,
@@ -25,6 +24,7 @@ from rest_framework.response import Response
 from .tasks import applyexternaltags
 from .tasks import BACKGROUND_QUEUE
 from .tasks import QUEUE
+from .tasks import remotecontentimport
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
When we enqueue the `remotecontentimport` task from `CollectionDownloadManager`, we can specify the priority of the jobs as high. However, when a user initiates a content download from the frontend using the tasks API, that's not possible. Since the upstream default priority is regular, it can get blocked behind any other queued tasks such as the background thumbnail downloads.

This adds a copy of upstream's `remotecontentimport` with the default priority set to high and arranges for it to be used throughout the plugin.

Helps: #739