### PR TITLE
Fix featured channel icons on discovery page

### DIFF
--- a/kolibri_explore_plugin/assets/src/views/DiscoveryPageContenPacks.vue
+++ b/kolibri_explore_plugin/assets/src/views/DiscoveryPageContenPacks.vue
@@ -91,7 +91,6 @@
   import AboutFooter from '../components/AboutFooter';
   import { ContentNodeExtrasResource } from '../apiResources';
   import navigationMixin from '../mixins/navigationMixin';
-  import { getBigThumbnail, getChannelIcon } from '../customApps';
 
   export default {
     name: 'DiscoveryPageContenPacks',
@@ -143,9 +142,7 @@
           no_available_filtering: true,
         }).then(({ data }) => {
           const nodes = data.map(n => {
-            n.bigThumbnail = getBigThumbnail(n);
-            n.thumbnail = getChannelIcon(n);
-            return n;
+            return this.rootNodes.find(c => c.id === n.channel_id);
           });
           this.sectionNodes['featured-channel'] = nodes;
         });


### PR DESCRIPTION
The featured channels for the discovery page were being constructed by finding the root node for channels tagged with `featured-channel`. However, using the node list directly breaks the fallback in `getChannelIcon` to use the channel's inlined thumbnail since the root node may not have a thumbnail specified. Instead, use the equivalent node from `rootNodes` since those already have the thumbnails resolved.

Fixes: #642