### PR TITLE
template-ui: Make various UI strings translatable

### DIFF
--- a/packages/template-ui/src/components/Breadcrumb.vue
+++ b/packages/template-ui/src/components/Breadcrumb.vue
@@ -95,7 +95,7 @@ export default {
     },
     currentItem() {
       if (this.isSearchPageCurrent) {
-        return { "title": "Search Keywords" };
+        return { "title": this.$tr('searchKeywords') };
       }
       return this.node;
     },
@@ -107,6 +107,12 @@ export default {
         path,
         query: { clearFilters: path === '/' },
       };
+    },
+  },
+  $trs: {
+    searchKeywords: {
+      message: 'Search Keywords',
+      context: 'Breadcrumb used when the user has performed a search',
     },
   },
 };

--- a/packages/template-ui/src/components/ChannelFooter.vue
+++ b/packages/template-ui/src/components/ChannelFooter.vue
@@ -13,7 +13,7 @@
       <template #right>
         <div v-if="isEndlessApp" class="endless-seal text-right">
           <div class="mb-1">
-            <span class="font-weight-bold">Best of the Web</span> curated by
+            {{ $tr('bestOfTheWeb') }}
           </div>
           <img :src="logo" aria-hidden="true">
         </div>
@@ -32,6 +32,14 @@ export default {
     ...mapState(['channel', 'isEndlessApp']),
     logo() {
       return EndlessLogo;
+    },
+  },
+  $trs: {
+    bestOfTheWeb: {
+      // FIXME: This isn’t translatable to languages where the logo can’t be a suffix,
+      // or RTL languages.
+      message: '<span class="font-weight-bold">Best of the Web</span> curated by ',
+      context: 'Footer curation message. The Endless Key logo is displayed just after the end of the sentence',
     },
   },
 };

--- a/packages/template-ui/src/components/ChannelFooter.vue
+++ b/packages/template-ui/src/components/ChannelFooter.vue
@@ -38,7 +38,7 @@ export default {
     bestOfTheWeb: {
       // FIXME: This isn’t translatable to languages where the logo can’t be a suffix,
       // or RTL languages.
-      message: '<span class="font-weight-bold">Best of the Web</span> curated by ',
+      message: '<strong>Best of the Web</strong> curated by ',
       context: 'Footer curation message. The Endless Key logo is displayed just after the end of the sentence',
     },
   },

--- a/packages/template-ui/src/components/EmptyResultsMessage.vue
+++ b/packages/template-ui/src/components/EmptyResultsMessage.vue
@@ -5,11 +5,10 @@
         <b-col cols="7">
           <slot>
             <h1 class="text-secondary">
-              There are no results containing all of your filter options.
+              {{ $tr('noResults') }}
             </h1>
             <h5 class="text-muted">
-              You can try fewer filter options, different filter options, or explore
-              the topics below.
+              {{ $tr('noResultsGuidance') }}
             </h5>
           </slot>
         </b-col>
@@ -24,7 +23,7 @@
       <b-row>
         <b-container>
           <h4 class="explore-title text-dark text-truncate w-75">
-            Explore topics
+            {{ $tr('exploreTopics') }}
           </h4>
         </b-container>
       </b-row>
@@ -45,6 +44,20 @@
     },
     computed: {
       ...mapState(['mainSections', 'cardColumns', 'mediaQuality']),
+    },
+    $trs: {
+      noResults: {
+        message: 'There are no results containing all of your filter options.',
+        context: 'Page content shown when there are no filter results',
+      },
+      noResultsGuidance: {
+        message: 'You can try fewer filter options, different filter options, or explore the topics below.',
+        context: 'Guidance shown to help the user work out what to do next when no filter results are found',
+      },
+      exploreTopics: {
+        message: 'Explore topics',
+        context: 'Heading shown when there are no filter results',
+      },
     },
   };
 </script>

--- a/packages/template-ui/src/components/FilterContent.vue
+++ b/packages/template-ui/src/components/FilterContent.vue
@@ -12,7 +12,7 @@
       variant="link"
       @click="clearFilter({})"
     >
-      clear filters
+      {{ $tr('clearFiltersButton') }}
     </b-button>
   </b-container>
 </template>
@@ -138,6 +138,12 @@ export default {
     sortOptionsByWeight(weightedOptions) {
       return Object.keys(weightedOptions).sort((a, b) => weightedOptions[b] - weightedOptions[a]);
     }
+  },
+  $trs: {
+    clearFiltersButton: {
+      message: 'clear filters',
+      context: 'Label for a button to clear media filters',
+    },
   },
 };
 </script>

--- a/packages/template-ui/src/components/FilterDropDown.vue
+++ b/packages/template-ui/src/components/FilterDropDown.vue
@@ -40,7 +40,7 @@
           @click="clearFilter({ filter })"
         >
           <CloseIcon class="mr-1" />
-          clear all
+          {{ $tr('clearAllButton') }}
         </b-button>
       </b-dropdown-form>
     </div>
@@ -95,6 +95,12 @@
 
         const selected = this.isSelected(filter, option);
         this.onOptionClick({ filter, option, checked: !selected });
+      },
+    },
+    $trs: {
+      clearAllButton: {
+        message: 'clear all',
+        context: 'Label for a button to clear all media filters',
       },
     },
   };

--- a/packages/template-ui/src/components/MainSections.vue
+++ b/packages/template-ui/src/components/MainSections.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-button-toolbar keyNav aria-label="Sections">
+  <b-button-toolbar keyNav :aria-label="$tr('sectionsLabel')">
     <b-button-group
       v-for="section in mainSections"
       :key="'menu-' + section.id"
@@ -32,6 +32,12 @@ export default {
   methods: {
     getNodeUrl(node) {
       return utils.getNodeUrl(node, this.channel.id);
+    },
+  },
+  $trs: {
+    sectionsLabel: {
+      message: 'Sections',
+      context: 'Accessibility label for the list of main sections',
     },
   },
 };

--- a/packages/template-ui/src/components/SectionsSearchRow.vue
+++ b/packages/template-ui/src/components/SectionsSearchRow.vue
@@ -12,7 +12,7 @@
             to="/search"
           >
             <MagnifyIcon :size="iconSize" class="mr-1" />
-            Search Keywords
+            {{ $tr('searchKeywordsButton') }}
           </b-button>
         </MainSections>
       </b-col>
@@ -26,7 +26,7 @@
           @click="downloadChannel()"
         >
           <CloudDownloadOutlineIcon :size="iconSize" class="mr-1" />
-          Download full channel
+          {{ $tr('downloadFullChannelButton') }}
         </b-button>
       </b-col>
 
@@ -56,6 +56,16 @@ export default {
   methods: {
     downloadChannel() {
       window.kolibri.downloadChannel();
+    },
+  },
+  $trs: {
+    searchKeywordsButton: {
+      message: 'Search Keywords',
+      context: 'Label for a button to search by keyword',
+    },
+    downloadFullChannelButton: {
+      message: 'Download full channel',
+      context: 'Label for a button to download a full channel',
     },
   },
 };

--- a/packages/template-ui/src/views/BundleSection.vue
+++ b/packages/template-ui/src/views/BundleSection.vue
@@ -23,7 +23,7 @@
       <div class="description mb-2 w-50" v-html="section.description"></div>
 
       <div v-if="section.license_description" id="license" class="my-3 text-muted">
-        <strong>License — {{ section.license_name }}</strong>
+        <strong>{{ $tr('licenseHeading', { license_name: section.license_name }) }}</strong>
         <p> {{ section.license_description }} </p>
       </div>
 
@@ -76,6 +76,12 @@ export default {
       if (this.sectionNodes.hasMoreNodes) {
         this.$emit('loadMoreNodes');
       }
+    },
+  },
+  $trs: {
+    licenseHeading: {
+      message: 'License — {license_name}',
+      context: 'Heading for the license of a bundle',
     },
   },
 };

--- a/packages/template-ui/src/views/Content.vue
+++ b/packages/template-ui/src/views/Content.vue
@@ -23,7 +23,7 @@
       </b-badge>
 
       <div v-if="content.license_description" id="license" class="my-3 text-muted">
-        <strong>License — {{ content.license_name }}</strong>
+        <strong>{{ $tr('licenseHeading', { license_name: content.license_name }) }}</strong>
         <p> {{ content.license_description }} </p>
       </div>
     </component>
@@ -40,7 +40,7 @@
       >
         <b-container>
           <h4 class="next-title text-dark text-truncate w-75">
-            Next in {{ sectionTitle }}
+            {{ $tr('nextIn', { name: sectionTitle }) }}
           </h4>
         </b-container>
       </EkCardGrid>
@@ -119,6 +119,16 @@ export default {
     onNextNodesUpdated(nodeId) {
       return this.onNodeUpdated(nodeId, this.nextNodesInTopic);
     }
+  },
+  $trs: {
+    licenseHeading: {
+      message: 'License — {license_name}',
+      context: 'Heading for the license of a bundle',
+    },
+    nextIn: {
+      message: 'Next in {name}',
+      context: 'Heading for the next part of a grid of content; {name} is a section name',
+    },
   },
 };
 </script>

--- a/packages/template-ui/src/views/Search.vue
+++ b/packages/template-ui/src/views/Search.vue
@@ -13,7 +13,7 @@
       <b-row alignH="between">
         <b-col>
           <b-form-checkbox v-model="hideUnavailable" name="check-hide-unavailable" switch>
-            Only downloaded items
+            {{ $tr('onlyDownloadedItems') }}
           </b-form-checkbox>
         </b-col>
       </b-row>
@@ -21,11 +21,10 @@
 
     <EmptyResultsMessage v-if="notFound" :showTopics="false">
       <h1 class="text-secondary">
-        Sorry, we can’t find any content that matches your search.
+        {{ $tr('noContentFound') }}
       </h1>
       <h5 class="text-muted">
-        You can try a different search, maybe use fewer words, or try one
-        of the topic suggestions below.
+        {{ $tr('noContentFoundGuidance') }}
       </h5>
     </EmptyResultsMessage>
 
@@ -38,7 +37,7 @@
       <b-row>
         <b-container>
           <h4 class="explore-title text-dark text-truncate w-75">
-            Explore topics
+            {{ $tr('exploreTopics') }}
           </h4>
         </b-container>
       </b-row>
@@ -52,7 +51,7 @@
       @nodeUpdated="onResultNodesUpdated"
     >
       <div class="font-weight-bold my-4 text-muted">
-        {{ totalResults }} Results
+        {{ $tr('resultsCount', { num_results: totalResults }) }}
         <EkKeywords :words="keywords" @click="removeKeyword" />
       </div>
     </EkCardGrid>
@@ -144,6 +143,28 @@ export default {
     },
     onResultNodesUpdated(nodeId) {
       return this.onNodeUpdated(nodeId, this.resultNodes);
+    },
+  },
+  $trs: {
+    onlyDownloadedItems: {
+      message: 'Only downloaded items',
+      context: 'Label for a search filter checkbox',
+    },
+    noContentFound: {
+      message: 'Sorry, we can’t find any content that matches your search.',
+      context: 'Text shown to the user when a search returns no results',
+    },
+    noContentFoundGuidance: {
+      message: 'You can try a different search, maybe use fewer words, or try one of the topic suggestions below.',
+      context: 'Guidance given to the user when no search results are found',
+    },
+    exploreTopics: {
+      message: 'Explore topics',
+      context: 'Heading for a section of content grid in the search results',
+    },
+    resultsCount: {
+      message: '{num_results, number, integer} {num_results, plural, one {Result} other {Results}}',
+      context: 'Number of results for a search',
     },
   },
 };

--- a/packages/template-ui/src/views/Test.vue
+++ b/packages/template-ui/src/views/Test.vue
@@ -1,4 +1,5 @@
 <template>
+  <!-- Deliberately not localised because it’s only test content -->
   <div class="root">
     <b-container class="bg-white pt-5">
       <h3 class="">


### PR DESCRIPTION
Previously they were hard-coded as English. A few strings were translatable, but most weren’t.

Signed-off-by: Philip Withnall <philip@tecnocode.co.uk>

Fixes: #772