### PR TITLE
ek-components: Make various UI strings translatable

### DIFF
--- a/packages/ek-components/src/components/EkCollapsibleCardGrid.vue
+++ b/packages/ek-components/src/components/EkCollapsibleCardGrid.vue
@@ -16,9 +16,9 @@
         variant="outline-dark"
         @click="showMore"
       >
-        <b-spinner v-if="loading" label="Spinning" small />
+        <b-spinner v-if="loading" :label="$tr('spinnerLabel')" small />
         <span v-else>
-          Show more
+          {{ $tr('showMoreButton') }}
         </span>
       </b-button>
       <b-button
@@ -28,7 +28,7 @@
         variant="outline-dark"
         @click="showLess"
       >
-        <span>Show less</span>
+        <span>{{ $tr('showLessButton') }}</span>
       </b-button>
     </b-row>
   </span>
@@ -130,6 +130,20 @@ export default {
     },
     onNodeUpdated(nodeId) {
       this.$emit('nodeUpdated', nodeId);
+    },
+  },
+  $trs: {
+    showMoreButton: {
+      message: 'Show more',
+      context: 'Button to expand a collapsible card grid',
+    },
+    showLessButton: {
+      message: 'Show less',
+      context: 'Button to collapse a collapsible card grid',
+    },
+    spinnerLabel: {
+      message: 'Spinning',
+      context: 'Label for a loading spinner',
     },
   },
 };

--- a/packages/ek-components/src/components/EkPrivacyPolicyText.vue
+++ b/packages/ek-components/src/components/EkPrivacyPolicyText.vue
@@ -1,4 +1,7 @@
 <template>
+  <!-- This is deliberately not translated for the moment, as the canonical
+       legal text will always be English.
+       See https://github.com/endlessm/kolibri-explore-plugin/issues/771#issuecomment-1697951996 -->
   <div>
     <p><em>Last Revised: October 5th, 2022</em></p>
     <p>

--- a/packages/ek-components/src/components/EkSearchBar.vue
+++ b/packages/ek-components/src/components/EkSearchBar.vue
@@ -20,7 +20,7 @@
         <input
           ref="searchInput"
           class="form-control"
-          placeholder="Type keywords to search"
+          :placeholder="$tr('searchPlaceholder')"
           :disabled="loading"
           :value="value"
           @keyup.enter="inputUpdated($event.target.value)"
@@ -99,6 +99,12 @@
         this.$emit('clear-input');
         this.focusSearchInput();
       }
+    },
+    $trs: {
+      searchPlaceholder: {
+        message: 'Type keywords to search',
+        context: 'Placeholder text in the search bar',
+      },
     },
   };
 </script>

--- a/packages/ek-components/src/components/EkSlidableGrid.vue
+++ b/packages/ek-components/src/components/EkSlidableGrid.vue
@@ -8,7 +8,7 @@
       aria-controls="carousel"
       @click="previous()"
     >
-      <ChevronLeftIcon title="Previous slide" />
+      <ChevronLeftIcon :title="$tr('previousSlide')" />
     </b-button>
     <div id="backgroud-block-left" :class="{ white: hasWhiteBackground }"></div>
     <div id="backgroud-block-right" :class="{ white: hasWhiteBackground }"></div>
@@ -21,7 +21,7 @@
       aria-controls="carousel"
       @click="next()"
     >
-      <ChevronRightIcon title="Next slide" />
+      <ChevronRightIcon :title="$tr('nextSlide')" />
     </b-button>
     <b-carousel
       ref="carousel"
@@ -136,6 +136,16 @@ export default {
         this.loading = true;
         this.$emit('loadMoreNodes');
       }
+    },
+  },
+  $trs: {
+    previousSlide: {
+      message: 'Previous slide',
+      context: 'Button to go to the previous slide in a slidable grid',
+    },
+    nextSlide: {
+      message: 'Next slide',
+      context: 'Button to go to the next slide in a slidable grid',
     },
   },
 };

--- a/packages/ek-components/src/components/EkTopicCard.vue
+++ b/packages/ek-components/src/components/EkTopicCard.vue
@@ -41,7 +41,7 @@
             <div v-else>
               <b-badge pill variant="primary">
                 <BundleIcon :size="20" />
-                Explore
+                {{ $tr('exploreBadge') }}
               </b-badge>
             </div>
           </b-card-text>
@@ -101,6 +101,12 @@ export default {
       return this.node.channel;
     },
   },
+  $trs: {
+    exploreBadge: {
+      message: 'Explore',
+      context: 'Label for a badge on a topic card',
+    },
+  }
 };
 </script>
 


### PR DESCRIPTION
Previously they were hard-coded as English. A few strings were
translatable, but most weren’t.

Signed-off-by: Philip Withnall <philip@tecnocode.co.uk>

Helps: #771