### PR TITLE
Really fix featured channel icons on discovery page

### DIFF
--- a/kolibri_explore_plugin/assets/src/views/DiscoveryPageContenPacks.vue
+++ b/kolibri_explore_plugin/assets/src/views/DiscoveryPageContenPacks.vue
@@ -91,6 +91,7 @@
   import AboutFooter from '../components/AboutFooter';
   import { ContentNodeExtrasResource } from '../apiResources';
   import navigationMixin from '../mixins/navigationMixin';
+  import { getBigThumbnail, getChannelIcon } from '../customApps';
 
   export default {
     name: 'DiscoveryPageContenPacks',
@@ -142,7 +143,9 @@
           no_available_filtering: true,
         }).then(({ data }) => {
           const nodes = data.map(n => {
-            return this.rootNodes.find(c => c.id === n.channel_id);
+            n.bigThumbnail = getBigThumbnail(n);
+            n.thumbnail = getChannelIcon(n);
+            return n;
           });
           this.sectionNodes['featured-channel'] = nodes;
         });


### PR DESCRIPTION
The previous fix to use `rootNodes` didn't work since that's populated asynchronously. Rather than try to block on that, this just repeats the channel lookup and mutates the node to have the channel's thumbnail fallbacks.

Fixes: #780