### PR TITLE
Don't run build:i18n from build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "kolibri_tools_i18n_modules": "--plugins kolibri_explore_plugin --namespace ek-components --searchPath ./packages/ek-components --namespace template-ui --searchPath ./packages/template-ui --namespace welcome-screen --searchPath ./packages/welcome-screen"
   },
   "scripts": {
-    "build": "yarn build:version && yarn build:packages && yarn deploy:welcome && yarn build:plugin && yarn build:info && yarn build:i18n",
+    "build": "yarn build:version && yarn build:packages && yarn deploy:welcome && yarn build:plugin && yarn build:info",
     "build:plugin": "./scripts/set_override.py default && kolibri-tools build prod --plugins kolibri_explore_plugin --transpile",
     "build:packages": "yarn build:libs",
     "build:libs": "lerna run build --ignore template-ui",


### PR DESCRIPTION
This is currently breaking the release because `i18n-extract-backend` always causes the `en.po` file to be updated. This in turn causes `setuptools_scm` to create a dev version of the wheel, which is promptly rejected by PyPI. For now, drop `build:i18n` from the generic `build` script until a better fix can be found.

Fixes: #787