### PR TITLE
Build welcome-screen.zip for release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,10 @@ jobs:
           yarn global add @vue/cli@v4.5.15
           yarn install --ignore-engines
 
-      - name: Build
+      - name: Build libs
+        run: yarn build:libs
+
+      - name: Build apps
         run: yarn build:apps
 
       - name: Deploy apps
@@ -60,6 +63,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           generate_release_notes: true
+          fail_on_unmatched_files: true
           files: |
             apps-bundle.zip
             packages/welcome-screen/welcome-screen.zip
@@ -70,6 +74,7 @@ jobs:
         with:
           tag_name: ${{ inputs.tagname }}
           generate_release_notes: true
+          fail_on_unmatched_files: true
           files: |
             apps-bundle.zip
             packages/welcome-screen/welcome-screen.zip


### PR DESCRIPTION
The welcome-screen.zip file is intended to be included as a release artifact, but it wasn't actually being built. Add the necessary build step and make `action-gh-release` fail when a pattern doesn't match any files. Without this it just prints a warning:

```
🤔 Pattern 'packages/welcome-screen/welcome-screen.zip' does not match any files.
```