### PR TITLE
template-ui: Hook i18n

### DIFF
--- a/kolibri_explore_plugin/assets/src/kolibriApi.js
+++ b/kolibri_explore_plugin/assets/src/kolibriApi.js
@@ -5,6 +5,7 @@ import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
 
 import router from 'kolibri.coreVue.router';
 import store from 'kolibri.coreVue.vuex.store';
+import { createTranslator } from 'kolibri.utils.i18n';
 import { utils } from 'ek-components';
 import { ChannelResource, ContentNodeResource } from './apiResources';
 import { showTopicsContentInLightbox } from './modules/topicsTree/handlers';
@@ -21,6 +22,9 @@ const DEFAULT_HIDE_UNAVAILABLE = false;
 class KolibriApi {
   constructor(channelId) {
     this.channelId = channelId;
+
+    // Cache of template-ui translators:
+    this.translators = {};
   }
 
   themeRenderer() {
@@ -233,6 +237,22 @@ class KolibriApi {
 
   get defaultHideUnavailable() {
     return DEFAULT_HIDE_UNAVAILABLE;
+  }
+
+  translate(nameSpace, defaultMessages, messageId, args) {
+    // Create the translator and add it to the cache only if needed:
+    let translator;
+    // FIXME this would be more readable by using the nullish coalescing
+    // assignment (??=) operator, but current linter is not happy:
+    // this.translators[nameSpace] ??= createTranslator(nameSpace, defaultMessages);
+    // const translator = this.translators[nameSpace];
+    if (nameSpace in this.translators) {
+      translator = this.translators[nameSpace];
+    } else {
+      translator = createTranslator(nameSpace, defaultMessages);
+      this.translators[nameSpace] = translator;
+    }
+    return translator.$tr(messageId, args);
   }
 }
 

--- a/packages/template-ui/src/main.js
+++ b/packages/template-ui/src/main.js
@@ -29,10 +29,9 @@ const ContentDownloadProxyPlugin = {
 
 Vue.use(ContentDownloadProxyPlugin);
 
-// FIXME hook i18n. This is a workaround to allow EK components that
-// use internationalization in the template-ui.
-Vue.prototype.$tr = function $tr(messageId) {
-  return this.$options.$trs[messageId];
+Vue.prototype.$tr = function $tr(messageId, args) {
+  const nameSpace = this.$options.name || this.$options.$trNameSpace;
+  return window.kolibri.translate(nameSpace, this.$options.$trs, messageId, args);
 };
 
 dynamicLoadComponents();


### PR DESCRIPTION
Pass the message ID through the API provided by the plugin.

On the plugin side, use kolibri i18n utility to create a translator for the given namespace and return the translated message.

Helps #604