### PR TITLE
Welcome app: Workaround $tr

### DIFF
--- a/packages/welcome-screen/src/main.js
+++ b/packages/welcome-screen/src/main.js
@@ -24,6 +24,11 @@ Vue.use(EkComponents);
 
 Vue.config.productionTip = false;
 
+// FIXME temporary workaround while migrating views using ek-components to the plugin
+Vue.prototype.$tr = function $tr(messageId) {
+  return this.$options.$trs[messageId];
+};
+
 const routes = [
   { path: '/', redirect: '/loading/initial' },
   { path: '/loading/default', component: Loading },


### PR DESCRIPTION
The localized ek-components are breaking the PackSelection view. Add the same workaround as template-ui. This should be temporary while we move this view to the plugin.

Helps #780