### PR TITLE
Only use LZMA compression for channel template zips

### DIFF
--- a/scripts/_common.py
+++ b/scripts/_common.py
@@ -37,7 +37,7 @@ HIGHLIGHTED_CONTENT_PATH = os.path.join(
 BUNDLE_EXCLUDE_GLOBS = ["*.map"]
 
 
-def bundle_zip(zip_name, compression=zipfile.ZIP_LZMA):
+def bundle_zip(zip_name, compression=zipfile.ZIP_DEFLATED):
     root_path = Path("dist")
 
     if not zip_name.endswith(".zip"):

--- a/scripts/build_template_overrides.py
+++ b/scripts/build_template_overrides.py
@@ -2,6 +2,7 @@
 # Copyright 2021 Endless OS Foundation LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 import subprocess
+import zipfile
 
 from _common import bundle_zip
 from _common import get_available_overrides
@@ -10,4 +11,4 @@ from _common import set_channel_override
 for override in get_available_overrides():
     set_channel_override(override)
     subprocess.run(["vue-cli-service", "build"])
-    bundle_zip(override)
+    bundle_zip(override, compression=zipfile.ZIP_LZMA)

--- a/scripts/bundle_bundles.py
+++ b/scripts/bundle_bundles.py
@@ -73,6 +73,9 @@ with tempfile.TemporaryDirectory() as dest_path:
         zip_name = f"{override}.zip"
         copy_bundle_zip(TEMPLATE_WORKSPACE, dest_path, override, zip_name)
 
+    # Note that this is using the zipfile default of no compression.
+    # That's fine as the inner bundles are compressed and it would take
+    # a long time to compress the outer zip with no appreciable savings.
     with zipfile.ZipFile("apps-bundle.zip", "w") as bundle:
         for dirname, dirs, files in os.walk(dest_path):
             for f in files:


### PR DESCRIPTION
Having `bundle_zip` default to LZMA compression meant it also applied to `welcome-screen.zip`. That's problematic since `unzip` can't handle that compression scheme. It's also unnecessary as `welcome-screen.zip` is only intended for releases. All of our apps will expand it into some location in their package, so the compression used is irrelevant.

Instead, make the default zlib deflate compression and explicitly request LZMA compression just for the channel templates. Note that the outer `apps-bundle.zip` is actually created with no compression, which is fine since it's entirely for distributing the already compressed channel templates.

See https://github.com/endlessm/endless-key-flatpak/issues/26.