### PR TITLE
Bump Python to 3.9

### DIFF
--- a/.github/workflows/bump2release.yml
+++ b/.github/workflows/bump2release.yml
@@ -36,10 +36,10 @@ jobs:
           git config --global user.name $GIT_USERNAME
           git config --global user.email $GIT_USEREMAIL
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.9
 
       - name: Set up Node
         uses: actions/setup-node@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.7
+    - name: Set up Python 3.9
       uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: 3.9
     - name: Set up Node
       uses: actions/setup-node@v3
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,10 +28,10 @@ jobs:
         with:
           ref: ${{ inputs.tagname }}
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.9
 
       - name: Install gettext for i18n
         run: |
@@ -94,10 +94,10 @@ jobs:
         with:
           ref: ${{ inputs.tagname }}
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.9
 
       - name: Install gettext for i18n
         run: |

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Python 3.7
+    - name: Set up Python 3.9
       uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: 3.9
 
     - name: Install gettext for i18n
       run: |


### PR DESCRIPTION
Original Pyhon 3.7 has been EOL since 2023-06-27 [1]. So, update Python to 3.9.

[1]: https://devguide.python.org/versions/#supported-versions

Fixes: https://github.com/endlessm/kolibri-explore-plugin/issues/795