### PR TITLE
Add Explore to Kolibri's sidebar

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,10 +2,12 @@
 # by yarn, so setuptools doesn’t know about it. Similarly for the compiled app.
 include kolibri_explore_plugin/static/build-info.json
 recursive-include kolibri_explore_plugin/static/kolibri_explore_plugin.app *
+recursive-include kolibri_explore_plugin/static/kolibri_explore_plugin.side_nav *
 
 # build/kolibri_explore_plugin.app_stats.json is needed by Kolibri at runtime,
 # but it is created at build time.
 include kolibri_explore_plugin/build/kolibri_explore_plugin.app_stats.json
+include kolibri_explore_plugin/build/kolibri_explore_plugin.side_nav_stats.json
 
 # This is the dist form of welcomeScreen, which is not committed to git (but its
 # source in packages/welcome-screen, is). It needs to be in the dist tarball

--- a/kolibri_explore_plugin/assets/src/components/DiscoveryNavBar.vue
+++ b/kolibri_explore_plugin/assets/src/components/DiscoveryNavBar.vue
@@ -12,7 +12,7 @@
         <ViewDashboardOutlineIcon />
         <!-- We want the text below in a line by itself,
          as it affects the spacing around it. -->
-        {{ $tr('discoveryLabel') }}
+        {{ exploreString('discoveryLabel') }}
       </b-nav-text>
       <b-nav-text
         class="btn discovery-tab py-3 rounded-0 text-primary"
@@ -22,7 +22,7 @@
         <MagnifyIcon />
         <!-- We want the text below in a line by itself,
          as it affects the spacing around it. -->
-        {{ $tr('libraryLabel') }}
+        {{ exploreString('libraryLabel') }}
       </b-nav-text>
     </b-button-group>
     <b-navbar-nav>
@@ -74,6 +74,7 @@
 
   import { mapMutations } from 'vuex';
   import { assets } from 'ek-components';
+  import commonExploreStrings from '../views/commonExploreStrings';
   import { PageNames } from '../constants';
 
   export default {
@@ -84,6 +85,7 @@
       MessageReplyTextOutlineIcon,
       ArrowDownIcon,
     },
+    mixins: [commonExploreStrings],
     data() {
       return {
         isOffline: false,
@@ -156,8 +158,6 @@
       },
     },
     $trs: {
-      discoveryLabel: 'Discovery',
-      libraryLabel: 'Library',
       feedbackLabel: 'Feedback',
       downloadLabel: 'Get Endless Key',
       downloadLabelShort: 'Get',

--- a/kolibri_explore_plugin/assets/src/routes/baseRoutes.js
+++ b/kolibri_explore_plugin/assets/src/routes/baseRoutes.js
@@ -1,0 +1,19 @@
+import { PageNames } from '../constants';
+
+// This file was created to have the core navigation routes available
+// without any other dependencies such as handlers, components, etc.
+
+export default {
+  home: {
+    name: PageNames.ROOT,
+    path: '/',
+  },
+  topicsRoot: {
+    name: PageNames.TOPICS_ROOT,
+    path: '/topics',
+  },
+  search: {
+    name: PageNames.SEARCH,
+    path: '/search',
+  },
+};

--- a/kolibri_explore_plugin/assets/src/views/ExploreSideNavEntry.js
+++ b/kolibri_explore_plugin/assets/src/views/ExploreSideNavEntry.js
@@ -1,0 +1,37 @@
+import navComponents from 'kolibri.utils.navComponents';
+import urls from 'kolibri.urls';
+import baseRoutes from '../routes/baseRoutes';
+import { exploreStrings } from './commonExploreStrings';
+
+const sideNavConfig = {
+  name: 'ExploreSideNavEntry',
+  get url() {
+    return urls['kolibri:kolibri_explore_plugin:explore']();
+  },
+  get routes() {
+    return [
+      {
+        label: exploreStrings.$tr('discoveryLabel'),
+        icon: 'dashboard',
+        route: baseRoutes.topicsRoot.path,
+        name: baseRoutes.topicsRoot.name,
+      },
+      {
+        label: exploreStrings.$tr('libraryLabel'),
+        icon: 'magnify',
+        route: baseRoutes.search.path,
+        name: baseRoutes.search.name,
+      },
+    ];
+  },
+  get label() {
+    return exploreStrings.$tr('exploreLabel');
+  },
+  icon: 'dashboard',
+  priority: 10,
+  bottomBar: true,
+};
+
+navComponents.register(sideNavConfig);
+
+export default sideNavConfig;

--- a/kolibri_explore_plugin/assets/src/views/commonExploreStrings.js
+++ b/kolibri_explore_plugin/assets/src/views/commonExploreStrings.js
@@ -3,6 +3,8 @@ import { createTranslator } from 'kolibri.utils.i18n';
 export const exploreStrings = createTranslator('CommonExploreStrings', {
   // Labels
   exploreLabel: 'Explore',
+  discoveryLabel: 'Discovery',
+  libraryLabel: 'Library',
 });
 
 export default {

--- a/kolibri_explore_plugin/buildConfig.js
+++ b/kolibri_explore_plugin/buildConfig.js
@@ -5,4 +5,10 @@ module.exports = [
       entry: './assets/src/app.js',
     },
   },
+  {
+    bundle_id: 'side_nav',
+    webpack_config: {
+      entry: './assets/src/views/ExploreSideNavEntry.js',
+    },
+  },
 ];

--- a/kolibri_explore_plugin/kolibri_plugin.py
+++ b/kolibri_explore_plugin/kolibri_plugin.py
@@ -10,6 +10,7 @@ from kolibri.core.auth.constants.user_kinds import LEARNER
 from kolibri.core.content.hooks import ContentNodeDisplayHook
 from kolibri.core.device.utils import is_landing_page
 from kolibri.core.device.utils import LANDING_PAGE_LEARN
+from kolibri.core.hooks import NavigationHook
 from kolibri.core.hooks import RoleBasedRedirectHook
 from kolibri.core.tasks.hooks import StorageHook
 from kolibri.core.webpack import hooks as webpack_hooks
@@ -41,6 +42,11 @@ class ExploreRedirect(RoleBasedRedirectHook):
     @property
     def url(self):
         return self.plugin_url(Explore, "explore")
+
+
+@register_hook
+class ExploreNavItem(NavigationHook):
+    bundle_id = "side_nav"
 
 
 @register_hook


### PR DESCRIPTION
This makes it possible for a user to navigate back to the Discovery UI from other parts of Kolibri.

Helps: https://github.com/endlessm/endless-key-flatpak/issues/26

-----

In particular, this was helpful with the Endless Key desktop app for a case where the default landing page is Kolibri's Device page.

![image](https://github.com/endlessm/kolibri-explore-plugin/assets/132063/9700760b-f5d4-419f-930c-7a1ed3feb49a)