### PR TITLE
build: Rework kolibri-tools commands for extracting translation messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
   "name": "kolibri-explore-plugin",
   "description": "Monorepo with kolibri's Discovery page and custom channel presentations.",
   "private": true,
-  "config": {
-    "kolibri_tools_i18n_modules": "--plugins kolibri_explore_plugin --namespace ek-components --searchPath ./packages/ek-components --namespace template-ui --searchPath ./packages/template-ui --namespace welcome-screen --searchPath ./packages/welcome-screen"
-  },
   "scripts": {
     "build": "yarn build:version && yarn build:packages && yarn deploy:welcome && yarn build:plugin && yarn build:info",
     "build:plugin": "./scripts/set_override.py default && kolibri-tools build prod --plugins kolibri_explore_plugin --transpile",
@@ -25,12 +22,12 @@
     "deploy:welcome": "cp -rf packages/welcome-screen/dist kolibri_explore_plugin/welcomeScreen && rm -f kolibri_explore_plugin/welcomeScreen/js/*map",
     "release": "./scripts/check_can_relese.sh && twine upload -s dist/*",
     "test:python": "python -m pytest",
-    "makemessages": "kolibri-tools i18n-extract-messages $npm_package_config_kolibri_tools_i18n_modules",
+    "makemessages": "kolibri-tools i18n-extract-messages --plugins kolibri_explore_plugin && kolibri-tools i18n-extract-messages --namespace ek-components --searchPath ./packages/ek-components && kolibri-tools i18n-extract-messages --namespace template-ui --searchPath ./packages/template-ui && kolibri-tools i18n-extract-messages --namespace welcome-screen --searchPath ./packages/welcome-screen",
     "i18n-extract-backend": "cd kolibri_explore_plugin && python -m kolibri manage makemessages --skip-update -l en --ignore 'node_modules/*' --ignore 'kolibri_explore_plugin/dist/*'",
     "i18n-extract-frontend": "yarn run makemessages",
     "i18n-extract": "yarn run i18n-extract-frontend && yarn run i18n-extract-backend",
     "i18n-django-compilemessages": "cd kolibri_explore_plugin && PYTHONPATH=\"..:$$PYTHONPATH\" python -m kolibri manage compilemessages --skip-update",
-    "i18n-download-translations": "kolibri-tools i18n-code-gen --output-dir ./kolibri_explore_plugin/assets/src --lang-info ./kolibri_explore_plugin/locale/language_info.json && yarn run i18n-django-compilemessages && yarn exec kolibri-tools i18n-create-message-files -- $npm_package_config_kolibri_tools_i18n_modules"
+    "i18n-download-translations": "kolibri-tools i18n-code-gen --output-dir ./kolibri_explore_plugin/assets/src --lang-info ./kolibri_explore_plugin/locale/language_info.json && yarn run i18n-django-compilemessages && yarn exec kolibri-tools i18n-create-message-files -- --plugins kolibri_explore_plugin && yarn exec kolibri-tools i18n-create-message-files -- --namespace ek-components --searchPath ./packages/ek-components && yarn exec kolibri-tools i18n-create-message-files -- --namespace template-ui --searchPath ./packages/template-ui && yarn exec kolibri-tools i18n-create-message-files -- --namespace welcome-screen --searchPath ./packages/welcome-screen"
   },
   "workspaces": [
     "kolibri_explore_plugin/assets",


### PR DESCRIPTION
It turns out that kolibri-tools only accepts one
`--namespace`/`--searchPath` argument pair on the command line, and silently ignores all of them except the last one that you provide.

This means the previous command was not extracting translatable messages for ek-components or template-ui, just the main plugin and the welcome-screen (which was the last pair of arguments).

Rearrange the commands so that each plugin/package is extracted separately. This works for message extraction, but unfortunately each invocation of `kolibri-tools` currently deletes *all* CSV files in the target directory, so we’re left with only the final CSV file.

That’s fixed by https://github.com/learningequality/kolibri/pull/11226. In the meantime, whoever periodically regenerates the CSV/JSON files will need to do so with that patch applied locally.