### PR TITLE
Remove package localization

### DIFF
--- a/packages/ek-components/src/components/EkCollapsibleCardGrid.vue
+++ b/packages/ek-components/src/components/EkCollapsibleCardGrid.vue
@@ -16,9 +16,9 @@
         variant="outline-dark"
         @click="showMore"
       >
-        <b-spinner v-if="loading" :label="$tr('spinnerLabel')" small />
+        <b-spinner v-if="loading" label="Spinning" small />
         <span v-else>
-          {{ $tr('showMoreButton') }}
+          Show more
         </span>
       </b-button>
       <b-button
@@ -28,7 +28,7 @@
         variant="outline-dark"
         @click="showLess"
       >
-        <span>{{ $tr('showLessButton') }}</span>
+        <span>Show less</span>
       </b-button>
     </b-row>
   </span>
@@ -130,20 +130,6 @@ export default {
     },
     onNodeUpdated(nodeId) {
       this.$emit('nodeUpdated', nodeId);
-    },
-  },
-  $trs: {
-    showMoreButton: {
-      message: 'Show more',
-      context: 'Button to expand a collapsible card grid',
-    },
-    showLessButton: {
-      message: 'Show less',
-      context: 'Button to collapse a collapsible card grid',
-    },
-    spinnerLabel: {
-      message: 'Spinning',
-      context: 'Label for a loading spinner',
     },
   },
 };

--- a/packages/ek-components/src/components/EkSearchBar.vue
+++ b/packages/ek-components/src/components/EkSearchBar.vue
@@ -20,7 +20,7 @@
         <input
           ref="searchInput"
           class="form-control"
-          :placeholder="$tr('searchPlaceholder')"
+          placeholder="Type keywords to search"
           :disabled="loading"
           :value="value"
           @keyup.enter="inputUpdated($event.target.value)"
@@ -99,12 +99,6 @@
         this.$emit('clear-input');
         this.focusSearchInput();
       }
-    },
-    $trs: {
-      searchPlaceholder: {
-        message: 'Type keywords to search',
-        context: 'Placeholder text in the search bar',
-      },
     },
   };
 </script>

--- a/packages/ek-components/src/components/EkSlidableGrid.vue
+++ b/packages/ek-components/src/components/EkSlidableGrid.vue
@@ -8,7 +8,7 @@
       aria-controls="carousel"
       @click="previous()"
     >
-      <ChevronLeftIcon :title="$tr('previousSlide')" />
+      <ChevronLeftIcon title="Previous slide" />
     </b-button>
     <div id="backgroud-block-left" :class="{ white: hasWhiteBackground }"></div>
     <div id="backgroud-block-right" :class="{ white: hasWhiteBackground }"></div>
@@ -21,7 +21,7 @@
       aria-controls="carousel"
       @click="next()"
     >
-      <ChevronRightIcon :title="$tr('nextSlide')" />
+      <ChevronRightIcon title="Next slide" />
     </b-button>
     <b-carousel
       ref="carousel"
@@ -136,16 +136,6 @@ export default {
         this.loading = true;
         this.$emit('loadMoreNodes');
       }
-    },
-  },
-  $trs: {
-    previousSlide: {
-      message: 'Previous slide',
-      context: 'Button to go to the previous slide in a slidable grid',
-    },
-    nextSlide: {
-      message: 'Next slide',
-      context: 'Button to go to the next slide in a slidable grid',
     },
   },
 };

--- a/packages/ek-components/src/components/EkTopicCard.vue
+++ b/packages/ek-components/src/components/EkTopicCard.vue
@@ -41,7 +41,7 @@
             <div v-else>
               <b-badge pill variant="primary">
                 <BundleIcon :size="20" />
-                {{ $tr('exploreBadge') }}
+                Explore
               </b-badge>
             </div>
           </b-card-text>
@@ -101,12 +101,6 @@ export default {
       return this.node.channel;
     },
   },
-  $trs: {
-    exploreBadge: {
-      message: 'Explore',
-      context: 'Label for a badge on a topic card',
-    },
-  }
 };
 </script>
 

--- a/packages/template-ui/src/components/Breadcrumb.vue
+++ b/packages/template-ui/src/components/Breadcrumb.vue
@@ -95,7 +95,7 @@ export default {
     },
     currentItem() {
       if (this.isSearchPageCurrent) {
-        return { "title": this.$tr('searchKeywords') };
+        return { "title": "Search Keywords" };
       }
       return this.node;
     },
@@ -107,12 +107,6 @@ export default {
         path,
         query: { clearFilters: path === '/' },
       };
-    },
-  },
-  $trs: {
-    searchKeywords: {
-      message: 'Search Keywords',
-      context: 'Breadcrumb used when the user has performed a search',
     },
   },
 };

--- a/packages/template-ui/src/components/ChannelFooter.vue
+++ b/packages/template-ui/src/components/ChannelFooter.vue
@@ -38,7 +38,7 @@ export default {
     bestOfTheWeb: {
       // FIXME: This isn’t translatable to languages where the logo can’t be a suffix,
       // or RTL languages.
-      message: '<strong>Best of the Web</strong> curated by ',
+      message: '<span class="font-weight-bold">Best of the Web</span> curated by ',
       context: 'Footer curation message. The Endless Key logo is displayed just after the end of the sentence',
     },
   },

--- a/packages/template-ui/src/components/ChannelFooter.vue
+++ b/packages/template-ui/src/components/ChannelFooter.vue
@@ -13,7 +13,7 @@
       <template #right>
         <div v-if="isEndlessApp" class="endless-seal text-right">
           <div class="mb-1">
-            {{ $tr('bestOfTheWeb') }}
+            <span class="font-weight-bold">Best of the Web</span> curated by
           </div>
           <img :src="logo" aria-hidden="true">
         </div>
@@ -32,14 +32,6 @@ export default {
     ...mapState(['channel', 'isEndlessApp']),
     logo() {
       return EndlessLogo;
-    },
-  },
-  $trs: {
-    bestOfTheWeb: {
-      // FIXME: This isn’t translatable to languages where the logo can’t be a suffix,
-      // or RTL languages.
-      message: '<span class="font-weight-bold">Best of the Web</span> curated by ',
-      context: 'Footer curation message. The Endless Key logo is displayed just after the end of the sentence',
     },
   },
 };

--- a/packages/template-ui/src/components/EmptyResultsMessage.vue
+++ b/packages/template-ui/src/components/EmptyResultsMessage.vue
@@ -5,10 +5,11 @@
         <b-col cols="7">
           <slot>
             <h1 class="text-secondary">
-              {{ $tr('noResults') }}
+              There are no results containing all of your filter options.
             </h1>
             <h5 class="text-muted">
-              {{ $tr('noResultsGuidance') }}
+              You can try fewer filter options, different filter options, or explore
+              the topics below.
             </h5>
           </slot>
         </b-col>
@@ -23,7 +24,7 @@
       <b-row>
         <b-container>
           <h4 class="explore-title text-dark text-truncate w-75">
-            {{ $tr('exploreTopics') }}
+            Explore topics
           </h4>
         </b-container>
       </b-row>
@@ -44,20 +45,6 @@
     },
     computed: {
       ...mapState(['mainSections', 'cardColumns', 'mediaQuality']),
-    },
-    $trs: {
-      noResults: {
-        message: 'There are no results containing all of your filter options.',
-        context: 'Page content shown when there are no filter results',
-      },
-      noResultsGuidance: {
-        message: 'You can try fewer filter options, different filter options, or explore the topics below.',
-        context: 'Guidance shown to help the user work out what to do next when no filter results are found',
-      },
-      exploreTopics: {
-        message: 'Explore topics',
-        context: 'Heading shown when there are no filter results',
-      },
     },
   };
 </script>

--- a/packages/template-ui/src/components/FilterContent.vue
+++ b/packages/template-ui/src/components/FilterContent.vue
@@ -12,7 +12,7 @@
       variant="link"
       @click="clearFilter({})"
     >
-      {{ $tr('clearFiltersButton') }}
+      clear filters
     </b-button>
   </b-container>
 </template>
@@ -138,12 +138,6 @@ export default {
     sortOptionsByWeight(weightedOptions) {
       return Object.keys(weightedOptions).sort((a, b) => weightedOptions[b] - weightedOptions[a]);
     }
-  },
-  $trs: {
-    clearFiltersButton: {
-      message: 'clear filters',
-      context: 'Label for a button to clear media filters',
-    },
   },
 };
 </script>

--- a/packages/template-ui/src/components/FilterDropDown.vue
+++ b/packages/template-ui/src/components/FilterDropDown.vue
@@ -40,7 +40,7 @@
           @click="clearFilter({ filter })"
         >
           <CloseIcon class="mr-1" />
-          {{ $tr('clearAllButton') }}
+          clear all
         </b-button>
       </b-dropdown-form>
     </div>
@@ -95,12 +95,6 @@
 
         const selected = this.isSelected(filter, option);
         this.onOptionClick({ filter, option, checked: !selected });
-      },
-    },
-    $trs: {
-      clearAllButton: {
-        message: 'clear all',
-        context: 'Label for a button to clear all media filters',
       },
     },
   };

--- a/packages/template-ui/src/components/MainSections.vue
+++ b/packages/template-ui/src/components/MainSections.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-button-toolbar keyNav :aria-label="$tr('sectionsLabel')">
+  <b-button-toolbar keyNav aria-label="Sections">
     <b-button-group
       v-for="section in mainSections"
       :key="'menu-' + section.id"
@@ -32,12 +32,6 @@ export default {
   methods: {
     getNodeUrl(node) {
       return utils.getNodeUrl(node, this.channel.id);
-    },
-  },
-  $trs: {
-    sectionsLabel: {
-      message: 'Sections',
-      context: 'Accessibility label for the list of main sections',
     },
   },
 };

--- a/packages/template-ui/src/components/SectionsSearchRow.vue
+++ b/packages/template-ui/src/components/SectionsSearchRow.vue
@@ -12,7 +12,7 @@
             to="/search"
           >
             <MagnifyIcon :size="iconSize" class="mr-1" />
-            {{ $tr('searchKeywordsButton') }}
+            Search Keywords
           </b-button>
         </MainSections>
       </b-col>
@@ -26,7 +26,7 @@
           @click="downloadChannel()"
         >
           <CloudDownloadOutlineIcon :size="iconSize" class="mr-1" />
-          {{ $tr('downloadFullChannelButton') }}
+          Download full channel
         </b-button>
       </b-col>
 
@@ -56,16 +56,6 @@ export default {
   methods: {
     downloadChannel() {
       window.kolibri.downloadChannel();
-    },
-  },
-  $trs: {
-    searchKeywordsButton: {
-      message: 'Search Keywords',
-      context: 'Label for a button to search by keyword',
-    },
-    downloadFullChannelButton: {
-      message: 'Download full channel',
-      context: 'Label for a button to download a full channel',
     },
   },
 };

--- a/packages/template-ui/src/views/BundleSection.vue
+++ b/packages/template-ui/src/views/BundleSection.vue
@@ -23,7 +23,7 @@
       <div class="description mb-2 w-50" v-html="section.description"></div>
 
       <div v-if="section.license_description" id="license" class="my-3 text-muted">
-        <strong>{{ $tr('licenseHeading', { license_name: section.license_name }) }}</strong>
+        <strong>License — {{ section.license_name }}</strong>
         <p> {{ section.license_description }} </p>
       </div>
 
@@ -76,12 +76,6 @@ export default {
       if (this.sectionNodes.hasMoreNodes) {
         this.$emit('loadMoreNodes');
       }
-    },
-  },
-  $trs: {
-    licenseHeading: {
-      message: 'License — {license_name}',
-      context: 'Heading for the license of a bundle',
     },
   },
 };

--- a/packages/template-ui/src/views/Content.vue
+++ b/packages/template-ui/src/views/Content.vue
@@ -23,7 +23,7 @@
       </b-badge>
 
       <div v-if="content.license_description" id="license" class="my-3 text-muted">
-        <strong>{{ $tr('licenseHeading', { license_name: content.license_name }) }}</strong>
+        <strong>License — {{ content.license_name }}</strong>
         <p> {{ content.license_description }} </p>
       </div>
     </component>
@@ -40,7 +40,7 @@
       >
         <b-container>
           <h4 class="next-title text-dark text-truncate w-75">
-            {{ $tr('nextIn', { name: sectionTitle }) }}
+            Next in {{ sectionTitle }}
           </h4>
         </b-container>
       </EkCardGrid>
@@ -119,16 +119,6 @@ export default {
     onNextNodesUpdated(nodeId) {
       return this.onNodeUpdated(nodeId, this.nextNodesInTopic);
     }
-  },
-  $trs: {
-    licenseHeading: {
-      message: 'License — {license_name}',
-      context: 'Heading for the license of a bundle',
-    },
-    nextIn: {
-      message: 'Next in {name}',
-      context: 'Heading for the next part of a grid of content; {name} is a section name',
-    },
   },
 };
 </script>

--- a/packages/template-ui/src/views/Search.vue
+++ b/packages/template-ui/src/views/Search.vue
@@ -13,7 +13,7 @@
       <b-row alignH="between">
         <b-col>
           <b-form-checkbox v-model="hideUnavailable" name="check-hide-unavailable" switch>
-            {{ $tr('onlyDownloadedItems') }}
+            Only downloaded items
           </b-form-checkbox>
         </b-col>
       </b-row>
@@ -21,10 +21,11 @@
 
     <EmptyResultsMessage v-if="notFound" :showTopics="false">
       <h1 class="text-secondary">
-        {{ $tr('noContentFound') }}
+        Sorry, we can’t find any content that matches your search.
       </h1>
       <h5 class="text-muted">
-        {{ $tr('noContentFoundGuidance') }}
+        You can try a different search, maybe use fewer words, or try one
+        of the topic suggestions below.
       </h5>
     </EmptyResultsMessage>
 
@@ -37,7 +38,7 @@
       <b-row>
         <b-container>
           <h4 class="explore-title text-dark text-truncate w-75">
-            {{ $tr('exploreTopics') }}
+            Explore topics
           </h4>
         </b-container>
       </b-row>
@@ -51,7 +52,7 @@
       @nodeUpdated="onResultNodesUpdated"
     >
       <div class="font-weight-bold my-4 text-muted">
-        {{ $tr('resultsCount', { num_results: totalResults }) }}
+        {{ totalResults }} Results
         <EkKeywords :words="keywords" @click="removeKeyword" />
       </div>
     </EkCardGrid>
@@ -143,28 +144,6 @@ export default {
     },
     onResultNodesUpdated(nodeId) {
       return this.onNodeUpdated(nodeId, this.resultNodes);
-    },
-  },
-  $trs: {
-    onlyDownloadedItems: {
-      message: 'Only downloaded items',
-      context: 'Label for a search filter checkbox',
-    },
-    noContentFound: {
-      message: 'Sorry, we can’t find any content that matches your search.',
-      context: 'Text shown to the user when a search returns no results',
-    },
-    noContentFoundGuidance: {
-      message: 'You can try a different search, maybe use fewer words, or try one of the topic suggestions below.',
-      context: 'Guidance given to the user when no search results are found',
-    },
-    exploreTopics: {
-      message: 'Explore topics',
-      context: 'Heading for a section of content grid in the search results',
-    },
-    resultsCount: {
-      message: '{num_results, number, integer} {num_results, plural, one {Result} other {Results}}',
-      context: 'Number of results for a search',
     },
   },
 };

--- a/packages/template-ui/src/views/Test.vue
+++ b/packages/template-ui/src/views/Test.vue
@@ -1,5 +1,4 @@
 <template>
-  <!-- Deliberately not localised because it’s only test content -->
   <div class="root">
     <b-container class="bg-white pt-5">
       <h3 class="">


### PR DESCRIPTION
The standalone packages have temporary `$tr` placeholders that don't currently handle translation objects or placeholders. For `stable`, revert the recent translation changes to essentially go back to the hardcoded English strings. The proper i18n fixes will land on `master` and full localization can be enabled for the the next major version.

See #797 for an example of current broken translations.