### PR TITLE
DownloadPage: Reload using the location API

### DIFF
--- a/kolibri_explore_plugin/assets/src/views/DownloadPage.vue
+++ b/kolibri_explore_plugin/assets/src/views/DownloadPage.vue
@@ -141,7 +141,10 @@
         return this.setUpdateInterval();
       },
       onConfirm() {
-        this.$router.go(0);
+        // Reload the page so the app fetches new data from the backend. Upon
+        // reloading, it will redirect to the landing page.
+        // <https://github.com/endlessm/kolibri-explore-plugin/issues/687>
+        window.location.reload();
       },
       updateLoop() {
         return this.updateDownload()


### PR DESCRIPTION
Previously, the page was reloaded using a particular effect of the Vue router's go() method, which behaved unexpectedly in some versions of WebKit.

Fixes: https://github.com/endlessm/kolibri-explore-plugin/issues/804