### PR TITLE
ek-components: Delay calling createTranslator() until actually needed

### DIFF
--- a/packages/ek-components/src/constants.js
+++ b/packages/ek-components/src/constants.js
@@ -1,84 +1,87 @@
-const createTranslator = window.kolibri.createTranslator;
+function getEkComponentsConstantsTranslator() {
+  const createTranslator = window.kolibri.createTranslator;
 
-// We have to call something called exactly ‘createTranslator’ for
-// i18n-extract-messages to work. See the documentation in kolibriApi.js.
-export const ekComponentsConstantsStrings = createTranslator('EkComponentsConstants', {
-  // For MediaTypeVerbs
-  discoverVerb: {
-    message: 'Discover',
-    context: 'Verb for using a media type',
-  },
-  watchVerb: {
-    message: 'Watch',
-    context: 'Verb for using a media type',
-  },
-  listenVerb: {
-    message: 'Listen',
-    context: 'Verb for using a media type',
-  },
-  readVerb: {
-    message: 'Read',
-    context: 'Verb for using a media type',
-  },
-  practiceVerb: {
-    message: 'Practice',
-    context: 'Verb for using a media type',
-  },
-  interactVerb: {
-    message: 'Interact',
-    context: 'Verb for using a media type',
-  },
+  // We have to call something called exactly ‘createTranslator’ for
+  // i18n-extract-messages to work. See the documentation in kolibriApi.js.
+  // This relies on createTranslator() caching the translator for us.
+  return createTranslator('EkComponentsConstants', {
+    // For MediaTypeVerbs
+    discoverVerb: {
+      message: 'Discover',
+      context: 'Verb for using a media type',
+    },
+    watchVerb: {
+      message: 'Watch',
+      context: 'Verb for using a media type',
+    },
+    listenVerb: {
+      message: 'Listen',
+      context: 'Verb for using a media type',
+    },
+    readVerb: {
+      message: 'Read',
+      context: 'Verb for using a media type',
+    },
+    practiceVerb: {
+      message: 'Practice',
+      context: 'Verb for using a media type',
+    },
+    interactVerb: {
+      message: 'Interact',
+      context: 'Verb for using a media type',
+    },
 
-  // For PackMetadata
-  explorerTitle: {
-    message: 'Explorer',
-    context: 'Title of a content pack',
-  },
-  explorerSubtitle: {
-    message: 'I like to learn about different cultures, places and ideas.',
-    context: 'Subtitle of a content pack',
-  },
-  artistTitle: {
-    message: 'Artist',
-    context: 'Title of a content pack',
-  },
-  artistSubtitle: {
-    message: 'I am creative and enjoy making things, music and dancing.',
-    context: 'Subtitle of a content pack',
-  },
-  scientistTitle: {
-    message: 'Scientist',
-    context: 'Title of a content pack',
-  },
-  scientistSubtitle: {
-    message: 'I love to investigate the world and do fun experiments.',
-    context: 'Subtitle of a content pack',
-  },
-  inventorTitle: {
-    message: 'Inventor',
-    context: 'Title of a content pack',
-  },
-  inventorSubtitle: {
-    message: 'I like to build things and solve problems.',
-    context: 'Subtitle of a content pack',
-  },
-  athleteTitle: {
-    message: 'Athlete',
-    context: 'Title of a content pack',
-  },
-  athleteSubtitle: {
-    message: 'I like to move my body and be with friends.',
-    context: 'Subtitle of a content pack',
-  },
-  curiousTitle: {
-    message: 'Curious',
-    context: 'Title of a content pack',
-  },
-  curiousSubtitle: {
-    message: 'I like to experiment with a bit of everything.',
-    context: 'Subtitle of a content pack',
-  },
-});
+    // For PackMetadata
+    explorerTitle: {
+      message: 'Explorer',
+      context: 'Title of a content pack',
+    },
+    explorerSubtitle: {
+      message: 'I like to learn about different cultures, places and ideas.',
+      context: 'Subtitle of a content pack',
+    },
+    artistTitle: {
+      message: 'Artist',
+      context: 'Title of a content pack',
+    },
+    artistSubtitle: {
+      message: 'I am creative and enjoy making things, music and dancing.',
+      context: 'Subtitle of a content pack',
+    },
+    scientistTitle: {
+      message: 'Scientist',
+      context: 'Title of a content pack',
+    },
+    scientistSubtitle: {
+      message: 'I love to investigate the world and do fun experiments.',
+      context: 'Subtitle of a content pack',
+    },
+    inventorTitle: {
+      message: 'Inventor',
+      context: 'Title of a content pack',
+    },
+    inventorSubtitle: {
+      message: 'I like to build things and solve problems.',
+      context: 'Subtitle of a content pack',
+    },
+    athleteTitle: {
+      message: 'Athlete',
+      context: 'Title of a content pack',
+    },
+    athleteSubtitle: {
+      message: 'I like to move my body and be with friends.',
+      context: 'Subtitle of a content pack',
+    },
+    curiousTitle: {
+      message: 'Curious',
+      context: 'Title of a content pack',
+    },
+    curiousSubtitle: {
+      message: 'I like to experiment with a bit of everything.',
+      context: 'Subtitle of a content pack',
+    },
+  });
+}
 
 // This maps to a translation ID. Use mediaTypeVerb() to translate it.
 export const MediaTypeVerbs = {
@@ -96,7 +99,7 @@ export const MediaTypeVerbs = {
 
 export function mediaTypeVerb(id) {
   if (id in MediaTypeVerbs)
-    return ekComponentsConstantsStrings.$tr(MediaTypeVerbs[id]);
+    return getEkComponentsConstantsTranslator().$tr(MediaTypeVerbs[id]);
   else
     return null;
 }
@@ -180,11 +183,11 @@ export const PackMetadata = [
 ];
 
 export function packMetadataTitle(pack) {
-  return ekComponentsConstantsStrings.$tr(pack.titleId);
+  return getEkComponentsConstantsTranslator().$tr(pack.titleId);
 }
 
 export function packMetadataSubtitle(pack) {
-  return ekComponentsConstantsStrings.$tr(pack.subtitleId);
+  return getEkComponentsConstantsTranslator().$tr(pack.subtitleId);
 }
 
 export default {

--- a/packages/ek-components/src/utils.js
+++ b/packages/ek-components/src/utils.js
@@ -5,41 +5,44 @@ import {
   StructuredTags,
 } from './constants';
 
-const createTranslator = window.kolibri.createTranslator;
+function getEkComponentsUtilsTranslator() {
+  const createTranslator = window.kolibri.createTranslator;
 
-// We have to call something called exactly ‘createTranslator’ for
-// i18n-extract-messages to work. See the documentation in kolibriApi.js.
-export const ekComponentsUtilsStrings = createTranslator('EkComponentsUtils', {
-  // For getTopicCardSubtitle and getCardSubtitle
-  videoCardSubtitle: {
-    message: '{count, number} {count, plural, one {video} other {videos}}',
-    context: 'Subtitle for a topic card containing a video',
-  },
-  audioCardSubtitle: {
-    message: '{count, number} {count, plural, one {audio} other {audios}}',
-    context: 'Subtitle for a topic card containing an audio',
-  },
-  documentCardSubtitle: {
-    message: '{count, number} {count, plural, one {document} other {documents}}',
-    context: 'Subtitle for a topic card containing a document',
-  },
-  htmlCardSubtitle: {
-    message: '{count, number} {count, plural, one {application} other {applications}}',
-    context: 'Subtitle for a topic card containing an HTML application',
-  },
-  zimCardSubtitle: {
-    message: '{count, number} {count, plural, one {article} other {articles}}',
-    context: 'Subtitle for a topic card containing a zim article',
-  },
-  resourceCardSubtitle: {
-    message: '{count, number} {count, plural, one {resource} other {resources}}',
-    context: 'Subtitle for a topic card containing a generic resource',
-  },
-  cardSubtitleByline: {
-    message: 'by {by_line}',
-    context: 'Subtitle for a non-topic card when a byline needs to be shown',
-  },
-});
+  // We have to call something called exactly ‘createTranslator’ for
+  // i18n-extract-messages to work. See the documentation in kolibriApi.js.
+  // This relies on createTranslator() caching the translator for us.
+  return createTranslator('EkComponentsUtils', {
+    // For getTopicCardSubtitle and getCardSubtitle
+    videoCardSubtitle: {
+      message: '{count, number} {count, plural, one {video} other {videos}}',
+      context: 'Subtitle for a topic card containing a video',
+    },
+    audioCardSubtitle: {
+      message: '{count, number} {count, plural, one {audio} other {audios}}',
+      context: 'Subtitle for a topic card containing an audio',
+    },
+    documentCardSubtitle: {
+      message: '{count, number} {count, plural, one {document} other {documents}}',
+      context: 'Subtitle for a topic card containing a document',
+    },
+    htmlCardSubtitle: {
+      message: '{count, number} {count, plural, one {application} other {applications}}',
+      context: 'Subtitle for a topic card containing an HTML application',
+    },
+    zimCardSubtitle: {
+      message: '{count, number} {count, plural, one {article} other {articles}}',
+      context: 'Subtitle for a topic card containing a zim article',
+    },
+    resourceCardSubtitle: {
+      message: '{count, number} {count, plural, one {resource} other {resources}}',
+      context: 'Subtitle for a topic card containing a generic resource',
+    },
+    cardSubtitleByline: {
+      message: 'by {by_line}',
+      context: 'Subtitle for a non-topic card when a byline needs to be shown',
+    },
+  });
+}
 
 /** Structured tags **/
 
@@ -125,26 +128,27 @@ export function getTopicCardSubtitle(node) {
   const leavesKinds = leaves.map((leaf) => leaf.kind);
   const uniqueLeavesKinds = new Set(leavesKinds);
   const count = node.children_count || leaves.length;
+  const translator = getEkComponentsUtilsTranslator();
 
   // See https://github.com/learningequality/le-utils/blob/master/le_utils/constants/content_kinds.py
   if (uniqueLeavesKinds.size > 1) {
-    return ekComponentsUtilsStrings.$tr('resourceCardSubtitle', { count: count });
+    return translator.$tr('resourceCardSubtitle', { count: count });
   } else {
     const kind = uniqueLeavesKinds.values().next().value;
 
     switch (kind) {
       case 'video':
-        return ekComponentsUtilsStrings.$tr('videoCardSubtitle', { count: count });
+        return translator.$tr('videoCardSubtitle', { count: count });
       case 'audio':
-        return ekComponentsUtilsStrings.$tr('audioCardSubtitle', { count: count });
+        return translator.$tr('audioCardSubtitle', { count: count });
       case 'document':
-        return ekComponentsUtilsStrings.$tr('documentCardSubtitle', { count: count });
+        return translator.$tr('documentCardSubtitle', { count: count });
       case 'html':
-        return ekComponentsUtilsStrings.$tr('htmlCardSubtitle', { count: count });
+        return translator.$tr('htmlCardSubtitle', { count: count });
       case 'zim':
-        return ekComponentsUtilsStrings.$tr('zimCardSubtitle', { count: count });
+        return translator.$tr('zimCardSubtitle', { count: count });
       default:
-        return ekComponentsUtilsStrings.$tr('resourceCardSubtitle', { count: count });
+        return translator.$tr('resourceCardSubtitle', { count: count });
     }
   }
 };
@@ -156,7 +160,7 @@ export function getCardSubtitle(node, fallback) {
   const byLine = node.author || node.license_owner || fallback;
 
   if (byLine)
-    return ekComponentsUtilsStrings.$tr('cardSubtitleByline', { by_line: byLine });
+    return getEkComponentsUtilsTranslator().$tr('cardSubtitleByline', { by_line: byLine });
   else
     return '';
 };


### PR DESCRIPTION
`createTranslator()` in ek-components now relies on `window.kolibri` being available, and that’s only initialised as part of the app setup, which is after all the imports are processed.

This causes the `createTranslator()` calls to fail at import time as `window.kolibri` is undefined.

Fix that by wrapping them in an internal function, which is only called when translated strings are actually needed. Rely on `createTranslator()` to cache the translator between calls.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

Fixes: #817