### PR TITLE
app: Fix typo in function call in SearchPage

### DIFF
--- a/kolibri_explore_plugin/assets/src/views/SearchPage.vue
+++ b/kolibri_explore_plugin/assets/src/views/SearchPage.vue
@@ -283,7 +283,7 @@
         this.query = '';
       },
       groupVerb(kind) {
-        return constants.mediaTypeVerb[kind === 'topic' ? 'bundle' : kind];
+        return constants.mediaTypeVerb(kind === 'topic' ? 'bundle' : kind);
       },
       removeKeyword(keyword) {
         const words = this.keywords.filter(k => k !== keyword);


### PR DESCRIPTION
This was introduced in 075a001cc0898a6567385e1876616741ec3c3746 when `MediaTypeVerbs[]` was replaced by `mediaTypeVerb()`.