### PR TITLE
Support release candidates

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -2,3 +2,7 @@
 current_version = 6.44.0
 commit = True
 tag = True
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<rc>\d+))?
+serialize = 
+	{major}.{minor}.{patch}rc{rc}
+	{major}.{minor}.{patch}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: (\.git/|\.tox/|\.venv/|build/|static/|dist/|node_modules/)
+exclude: (\.git/|\.tox/|\.venv/|\.bumpversion.cfg$|build/|static/|dist/|node_modules/)
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v2.0.0

--- a/README.md
+++ b/README.md
@@ -213,18 +213,6 @@ git push
 git push origin NEW_TAG
 ```
 
-Then build:
-
-```bash
-yarn build-dist
-```
-
-And finally upload the built `.whl` file to PyPi:
-
-```bash
-yarn release
-```
-
 ### How to display the build information
 
 To show the build information in the front page, as a tag in top right corner,

--- a/README.md
+++ b/README.md
@@ -218,6 +218,36 @@ The `bump-version` script can also be run with options such as
 also specify `--current-version` to see the effect without actually
 changing the current version. See `bumpversion --help` for all options.
 
+#### Release candidates
+
+PyPI and `pip` support release candidates with the `rc<N>` suffix. Prior
+to major releases it may be helpful to build and publish release
+candidates so they can be tested prior to general availability. Our
+`bumpversion` configuration has limited support for release candidates,
+so care should be taken to ensure the new version comes out correctly.
+
+To begin a release candidate series, the version must be fully specified:
+
+```bash
+yarn bump-version major "Komodo Dragon" --new-version 7.0.0rc1
+```
+
+To make the next release candidate, run:
+
+``` bash
+yarn bump-version rc
+```
+
+Finally, to end a release candidate series, the version must be fully
+specified again:
+
+``` bash
+yarn bump-version major "Komodo Dragon" --new-version 7.0.0
+```
+
+In all cases, the commit and tag must be pushed to the remote as
+explained above.
+
 ### How to display the build information
 
 To show the build information in the front page, as a tag in top right corner,

--- a/README.md
+++ b/README.md
@@ -213,6 +213,11 @@ git push
 git push origin NEW_TAG
 ```
 
+The `bump-version` script can also be run with options such as
+`--dry-run --list` or `--no-commit` to see what will happen. You can
+also specify `--current-version` to see the effect without actually
+changing the current version. See `bumpversion --help` for all options.
+
 ### How to display the build information
 
 To show the build information in the front page, as a tag in top right corner,

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -13,6 +13,11 @@ VERSION_FILENAME = os.path.join("kolibri_explore_plugin", "VERSION")
 
 
 def _update_version_name(version_name):
+    with open(VERSION_FILENAME, "r") as fd:
+        current_name = fd.read().strip()
+    if current_name == version_name.strip():
+        return
+
     print(f"Committing new version name: {version_name}")
     with open(VERSION_FILENAME, "w") as fd:
         fd.write(version_name.strip() + "\n")

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
     ap.add_argument(
         "part",
         metavar="PART",
-        choices=("major", "minor"),
+        choices=("major", "minor", "rc"),
         help="Part of the version number to be bumped",
     )
     ap.add_argument(


### PR DESCRIPTION
This adds some support for creating release candidates with `bumpversion`. Since `pip` considers a package with an `rc<N>` suffix to be a pre-release, it won't be installed without specifying the version or using `--pre`. This should allow us to get some testing on a Narwhal RC without making it generally available.