### PR TITLE
Save wheel and tarball as artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,36 +54,33 @@ jobs:
       - name: Build libs
         run: pipenv run yarn build:libs
 
+      - name: Upload loading-screen.zip
+        uses: actions/upload-artifact@v3
+        with:
+          name: loading-screen.zip
+          path: packages/loading-screen/loading-screen.zip
+          if-no-files-found: error
+
       - name: Build apps
         run: pipenv run yarn build:apps
 
       - name: Deploy apps
         run: pipenv run yarn deploy:apps
 
-      - name: Release when triggered from a tag push
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
+      - name: Upload apps-bundle.zip
+        uses: actions/upload-artifact@v3
         with:
-          generate_release_notes: true
-          fail_on_unmatched_files: true
-          files: |
-            apps-bundle.zip
-            packages/loading-screen/loading-screen.zip
-
-      - name: Release when triggered from workflow_call
-        uses: softprops/action-gh-release@v1
-        if: startsWith(inputs.tagname, 'v')
-        with:
-          tag_name: ${{ inputs.tagname }}
-          generate_release_notes: true
-          fail_on_unmatched_files: true
-          files: |
-            apps-bundle.zip
-            packages/loading-screen/loading-screen.zip
+          name: apps-bundle.zip
+          path: apps-bundle.zip
+          if-no-files-found: error
 
 
   build_kolibri-explore-plugin_whl:
     runs-on: ubuntu-latest
+
+    outputs:
+      whl-filename: ${{ steps.whl-filename.outputs.whl-filename }}
+      tar-filename: ${{ steps.tar-filename.outputs.tar-filename }}
 
     steps:
       - name: Checkout from none-workflow_call
@@ -128,8 +125,67 @@ jobs:
           pipenv run yarn build-dist
           ls -l dist/
 
+      - name: Get wheel filename
+        id: whl-filename
+        run: echo "whl-filename=$(ls dist | grep '\.whl$')" >> $GITHUB_OUTPUT
+
+      - name: Upload wheel
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.whl-filename.outputs.whl-filename }}
+          path: dist/${{ steps.whl-filename.outputs.whl-filename }}
+          if-no-files-found: error
+
+      - name: Get tarball filename
+        id: tar-filename
+        run: echo "tar-filename=$(ls dist | grep '\.tar\.')" >> $GITHUB_OUTPUT
+
+      - name: Upload tarball
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.tar-filename.outputs.tar-filename }}
+          path: dist/${{ steps.tar-filename.outputs.tar-filename }}
+          if-no-files-found: error
+
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/') || startsWith(inputs.tagname, 'v')
+    needs: [build_apps-bundle, build_kolibri-explore-plugin_whl]
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: dist
+
+      - name: Release when triggered from a tag push
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: |
+            dist/${{ needs.build_kolibri-explore-plugin_whl.outputs.whl-filename }}
+            dist/${{ needs.build_kolibri-explore-plugin_whl.outputs.tar-filename }}
+            dist/apps-bundle.zip
+            dist/loading-screen.zip
+
+      - name: Release when triggered from workflow_call
+        uses: softprops/action-gh-release@v1
+        if: startsWith(inputs.tagname, 'v')
+        with:
+          tag_name: ${{ inputs.tagname }}
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: |
+            dist/${{ needs.build_kolibri-explore-plugin_whl.outputs.whl-filename }}
+            dist/${{ needs.build_kolibri-explore-plugin_whl.outputs.tar-filename }}
+            dist/apps-bundle.zip
+            dist/loading-screen.zip
+
       - name: Release to PyPI
-        if: startsWith(github.ref, 'refs/tags/') || startsWith(inputs.tagname, 'v')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
@@ -137,8 +193,7 @@ jobs:
 
   trigger_endless-key-app:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') || startsWith(inputs.tagname, 'v')
-    needs: [build_apps-bundle, build_kolibri-explore-plugin_whl]
+    needs: [release]
 
     steps:
       - name: Get tag name as the release version when at a tag
@@ -168,8 +223,7 @@ jobs:
 
   trigger_kolibri-installer-android:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') || startsWith(inputs.tagname, 'v')
-    needs: [build_apps-bundle, build_kolibri-explore-plugin_whl]
+    needs: [release]
     env:
       branch: ${{ github.ref }}
 


### PR DESCRIPTION
We always build the wheel and tarball for every build. Rather than throwing them away, store them as artifacts. After that, rearrange the release into a separate job that downloads the built artifacts and includes them as release artifacts.