### PR TITLE
app: Mark some more strings as translatable

### DIFF
--- a/kolibri_explore_plugin/assets/src/views/welcome/PackReadyPage.vue
+++ b/kolibri_explore_plugin/assets/src/views/welcome/PackReadyPage.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <WelcomeBase title="Awesome! Your Starter Pack is ready">
+  <WelcomeBase :title="$tr('packReadyTitle')">
     <template #body>
       <div class="pack-background"></div>
       <b-button
@@ -10,13 +10,13 @@
         variant="primary"
         @click="downloadContent"
       >
-        Download My Starter Pack
+        {{ $tr('downloadContentButton') }}
       </b-button>
       <p>
         <b-link
           :to="{ name: PageNames.WELCOME_PACK_SELECTION }"
         >
-          Not sure? Let's go back to all the options.
+          {{ $tr('downloadContentBackButton') }}
         </b-link>
       </p>
     </template>
@@ -61,6 +61,21 @@
       },
       onOnline() {
         this.isOffline = false;
+      },
+    },
+    $trs: {
+      packReadyTitle: {
+        message: 'Awesome! Your Starter Pack is ready',
+        context:
+          'Title heading for when the user has chosen a starter content pack and is about to download it',
+      },
+      downloadContentButton: {
+        message: 'Download My Starter Pack',
+        context: 'Button label for downloading a content pack',
+      },
+      downloadContentBackButton: {
+        message: 'Not sure? Let’s go back to all the options.',
+        context: 'Button label for going back and choosing a different starter content pack',
       },
     },
   };

--- a/kolibri_explore_plugin/assets/src/views/welcome/PackSelectionPage.vue
+++ b/kolibri_explore_plugin/assets/src/views/welcome/PackSelectionPage.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <WelcomeBase title="Which option sounds most like you?">
+  <WelcomeBase :title="$tr('packSelectionTitle')">
     <template #body>
 
       <b-container class="no-container-padding text-left">
@@ -57,6 +57,13 @@
         // FIXME: This is hardcoded to the (currently) only option.
         const name = '0001';
         this.$router.push({ name: PageNames.WELCOME_PACK_READY, params: { grade, name } });
+      },
+    },
+    $trs: {
+      packSelectionTitle: {
+        message: 'Which option sounds most like you?',
+        context:
+          'Title heading for when the user is asked to choose an initial content pack to download',
       },
     },
   };

--- a/kolibri_explore_plugin/assets/src/views/welcome/WelcomePage.vue
+++ b/kolibri_explore_plugin/assets/src/views/welcome/WelcomePage.vue
@@ -6,21 +6,19 @@
     <div class="d-flex flex-column flex-grow-1 w-100">
       <div class="flex-grow-1 welcome-background-top"></div>
       <div class="content p-3 pb-5 position-relative">
-        <h1>
-          Welcome to Endless Key!
-        </h1>
+        <h1>{{ $tr('welcomeTitle') }}</h1>
         <div class="mb-4 mt-4">
           <b-button
             pill
             variant="primary"
             :to="{ name: PageNames.WELCOME_PACK_SELECTION }"
           >
-            Get Started
+            {{ $tr('getStartedButton') }}
           </b-button>
         </div>
         <p>
           <b-link v-b-modal.privacy-policy-modal>
-            Privacy Policy
+            {{ $tr('privacyPolicy') }}
           </b-link>
         </p>
       </div>
@@ -33,7 +31,7 @@
       >
         <div class="bg-white modal-wrapper text-dark">
           <h3 class="pt-3 text-primary">
-            Privacy Policy
+            {{ $tr('privacyPolicy') }}
           </h3>
           <EkPrivacyPolicyText class="pb-3" />
         </div>
@@ -56,6 +54,20 @@
       return {
         PageNames,
       };
+    },
+    $trs: {
+      welcomeTitle: {
+        message: 'Welcome to Endless Key!',
+        context: 'Title heading for the welcome page',
+      },
+      getStartedButton: {
+        message: 'Get Started',
+        context: 'Button label on the welcome page',
+      },
+      privacyPolicy: {
+        message: 'Privacy Policy',
+        context: 'Footer link',
+      },
     },
   };
 


### PR DESCRIPTION
These came from the welcome-screen, and can now be translated as part of the main app.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

Helps: #770