### PR TITLE
Improve release workflow

### DIFF
--- a/.github/workflows/bump2release.yml
+++ b/.github/workflows/bump2release.yml
@@ -83,15 +83,15 @@ jobs:
           echo "tagname=$tagname" >> $GITHUB_OUTPUT
 
 
-  build_for_tag:
+  release:
     # Using the GITHUB_TOKEN in a workflow will not create a new workflow run to
     # prevent from accidentally creating recursive workflow runs. So, call the
     # following workflow here and inherit the secrets by design.
     # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
-    name: Build for release
+    name: Release
     needs: bump_version
     if: startsWith(needs.bump_version.outputs.tagname, 'v')
-    uses: ./.github/workflows/main.yml
+    uses: ./.github/workflows/release.yml
     with:
       tagname: ${{ needs.bump_version.outputs.tagname }}
     secrets: inherit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,11 +6,18 @@ on:
   pull_request:
   workflow_call:
     inputs:
-      tagname:
-        description: 'The git tag name for release'
+      ref:
+        description: 'The git ref to build'
         default: ''
         required: true
         type: string
+    outputs:
+      whl-filename:
+        description: Wheel filename
+        value: ${{ jobs.wheel.outputs.whl-filename }}
+      tar-filename:
+        description: Tarball filename
+        value: ${{ jobs.wheel.outputs.tar-filename }}
   workflow_dispatch:
 
 jobs:
@@ -22,8 +29,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          # If the tagname is empty, checkout falls back to github.ref.
-          ref: ${{ inputs.tagname }}
+          # If the ref input is empty, checkout falls back to github.ref.
+          ref: ${{ inputs.ref }}
 
       - name: Set up Python 3.9
         uses: actions/setup-python@v4
@@ -84,8 +91,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          # If the tagname is empty, checkout falls back to github.ref.
-          ref: ${{ inputs.tagname }}
+          # If the ref input is empty, checkout falls back to github.ref.
+          ref: ${{ inputs.ref }}
           # The full git history is needed so that setuptools_scm can derive
           # the version number correctly.
           fetch-depth: 0
@@ -143,125 +150,3 @@ jobs:
           name: ${{ steps.tar-filename.outputs.tar-filename }}
           path: dist/${{ steps.tar-filename.outputs.tar-filename }}
           if-no-files-found: error
-
-
-  release:
-    name: Release
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') || startsWith(inputs.tagname, 'v')
-    needs: [bundles, wheel]
-
-    steps:
-      # If you download all artifacts or a single artifact while
-      # specifying path, download-artifact creates an extra directory
-      # with the artifact name. We just want the single artifacts, so
-      # download them individually into the current directory.
-      - name: Download wheel
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ needs.wheel.outputs.whl-filename }}
-
-      - name: Download tarball
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ needs.wheel.outputs.tar-filename }}
-
-      - name: Download apps-bundle.zip
-        uses: actions/download-artifact@v3
-        with:
-          name: apps-bundle.zip
-
-      - name: Download loading-screen.zip
-        uses: actions/download-artifact@v3
-        with:
-          name: loading-screen.zip
-
-      - name: Create GitHub release
-        uses: softprops/action-gh-release@v1
-        with:
-          # If tag_name is empty, action-gh-release falls back to github.ref.
-          tag_name: ${{ inputs.tagname }}
-          generate_release_notes: true
-          fail_on_unmatched_files: true
-          files: |
-            ${{ needs.wheel.outputs.whl-filename }}
-            ${{ needs.wheel.outputs.tar-filename }}
-            apps-bundle.zip
-            loading-screen.zip
-
-      - name: Move PyPI artifacts to dist directory
-        run: |
-          mkdir -p dist
-          mv "${{ needs.wheel.outputs.whl-filename }}" dist
-          mv "${{ needs.wheel.outputs.tar-filename }}" dist
-
-      - name: Release to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
-
-
-  trigger_endless-key-app:
-    name: Trigger endless-key-app release
-    runs-on: ubuntu-latest
-    needs: [release]
-
-    steps:
-      - name: Get tag name as the release version when at a tag
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          echo "VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
-
-      - name: Get tag name as the release version from input
-        if: ${{ !startsWith(github.ref, 'refs/tags/') && startsWith(inputs.tagname, 'v') }}
-        run: |
-          echo "VERSION=${{ inputs.tagname }}" >> $GITHUB_ENV
-
-      - name: Trigger building endless-key-app
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.REPOSITORY_DISPATCH_TOKEN }}
-          script: |
-            await github.rest.repos.createDispatchEvent({
-              owner: "endlessm",
-              repo: "endless-key-app",
-              event_type: "kolibri-explore-plugin-release",
-              client_payload: {
-                VERSION: "${{ env.VERSION }}",
-              }
-            })
-
-
-  trigger_kolibri-installer-android:
-    name: Trigger kolibri-installer-android release
-    runs-on: ubuntu-latest
-    needs: [release]
-    env:
-      branch: ${{ github.ref }}
-
-    steps:
-      - name: Set branch if this is triggered by bump2release.yml
-        if: startsWith(inputs.tagname, 'v')
-        run: |
-          # The kolibri-explore-plugin release flow from bump2release.yml will
-          # append a new commit to master branch. Therefore, the github.ref is
-          # not at the latest commit. Checkout master instead.
-          echo "branch=${{ inputs.tagname }}" >> $GITHUB_ENV
-
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ env.branch }}
-
-      - name: Install trigger_jenkins dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y python3-pip
-          python3 -m pip install requests python-jenkins
-
-      - name: Trigger building kolibri-installer-android
-        run: |
-          ./scripts/trigger_jenkins.py kolibri-installer-android UPLOAD=true
-        env:
-          JENKINS_USER: ${{ secrets.JENKINS_USERNAME }}
-          JENKINS_PASSWORD: ${{ secrets.JENKINS_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,11 @@ jobs:
       tag: ${{ steps.set-tag.outputs.tag }}
       ref: "refs/tags/${{ steps.set-tag.outputs.tag }}"
 
+      # Don't trigger app builds for major or rc releases since they're
+      # likely to fail or be broken.
+      trigger-apps: >-
+        ${{ (endsWith(steps.set-tag.outputs.tag, '.0.0') || contains(steps.set-tag.outputs.tag, 'rc')) && 'false' || 'true' }}
+
     steps:
       - name: Validate tagname input
         if: ${{ inputs.tagname && !startsWith(inputs.tagname, 'v') }}
@@ -107,6 +112,7 @@ jobs:
     name: Trigger endless-key-app release
     runs-on: ubuntu-latest
     needs: [validate, release]
+    if: ${{ fromJSON(needs.validate.outputs.trigger-apps) }}
 
     steps:
       - name: Trigger building endless-key-app
@@ -127,6 +133,7 @@ jobs:
     name: Trigger kolibri-installer-android release
     runs-on: ubuntu-latest
     needs: [validate, release]
+    if: ${{ fromJSON(needs.validate.outputs.trigger-apps) }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,17 +14,46 @@ on:
   workflow_dispatch:
 
 jobs:
+  validate:
+    name: Validate release tag
+    runs-on: ubuntu-latest
+
+    outputs:
+      # Normalize the tag and ref names here so they can be used below.
+      tag: ${{ steps.set-tag.outputs.tag }}
+      ref: "refs/tags/${{ steps.set-tag.outputs.tag }}"
+
+    steps:
+      - name: Validate tagname input
+        if: ${{ inputs.tagname && !startsWith(inputs.tagname, 'v') }}
+        uses: actions/github-script@v3
+        with:
+          script: |
+            core.setFailed('Input tagname must begin with v')
+
+      - name: Validate triggered ref
+        if: ${{ !inputs.tagname && !startsWith(github.ref, 'refs/tags/v') }}
+        uses: actions/github-script@v3
+        with:
+          script: |
+            core.setFailed('Release must run from a v* tag')
+
+      - name: Normalize tag name
+        id: set-tag
+        run: |
+          echo "tag=${{ inputs.tagname && inputs.tagname || github.ref_name }}" >> "$GITHUB_OUTPUT"
+
   build:
     name: Build
+    needs: validate
     uses: ./.github/workflows/main.yml
     with:
-      # If tagname is empty, the build will fallback to github.ref.
-      ref: ${{ inputs.tagname }}
+      ref: ${{ needs.validate.outputs.ref }}
 
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: build
+    needs: [validate, build]
 
     steps:
       # If you download all artifacts or a single artifact while
@@ -54,8 +83,7 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v1
         with:
-          # If tag_name is empty, action-gh-release falls back to github.ref.
-          tag_name: ${{ inputs.tagname }}
+          tag_name: ${{ needs.validate.outputs.tag }}
           generate_release_notes: true
           fail_on_unmatched_files: true
           files: |
@@ -78,19 +106,9 @@ jobs:
   trigger_endless-key-app:
     name: Trigger endless-key-app release
     runs-on: ubuntu-latest
-    needs: [release]
+    needs: [validate, release]
 
     steps:
-      - name: Get tag name as the release version when at a tag
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          echo "VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
-
-      - name: Get tag name as the release version from input
-        if: ${{ !startsWith(github.ref, 'refs/tags/') && startsWith(inputs.tagname, 'v') }}
-        run: |
-          echo "VERSION=${{ inputs.tagname }}" >> $GITHUB_ENV
-
       - name: Trigger building endless-key-app
         uses: actions/github-script@v6
         with:
@@ -101,30 +119,20 @@ jobs:
               repo: "endless-key-app",
               event_type: "kolibri-explore-plugin-release",
               client_payload: {
-                VERSION: "${{ env.VERSION }}",
+                VERSION: "${{ needs.validate.output.tag }}",
               }
             })
 
   trigger_kolibri-installer-android:
     name: Trigger kolibri-installer-android release
     runs-on: ubuntu-latest
-    needs: [release]
-    env:
-      branch: ${{ github.ref }}
+    needs: [validate, release]
 
     steps:
-      - name: Set branch if this is triggered by bump2release.yml
-        if: startsWith(inputs.tagname, 'v')
-        run: |
-          # The kolibri-explore-plugin release flow from bump2release.yml will
-          # append a new commit to master branch. Therefore, the github.ref is
-          # not at the latest commit. Checkout master instead.
-          echo "branch=${{ inputs.tagname }}" >> $GITHUB_ENV
-
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ env.branch }}
+          ref: ${{ needs.validate.outputs.ref }}
 
       - name: Install trigger_jenkins dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,140 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_call:
+    inputs:
+      tagname:
+        description: 'The git tag name for release'
+        default: ''
+        required: true
+        type: string
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build
+    uses: ./.github/workflows/main.yml
+    with:
+      # If tagname is empty, the build will fallback to github.ref.
+      ref: ${{ inputs.tagname }}
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      # If you download all artifacts or a single artifact while
+      # specifying path, download-artifact creates an extra directory
+      # with the artifact name. We just want the single artifacts, so
+      # download them individually into the current directory.
+      - name: Download wheel
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.build.outputs.whl-filename }}
+
+      - name: Download tarball
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.build.outputs.tar-filename }}
+
+      - name: Download apps-bundle.zip
+        uses: actions/download-artifact@v3
+        with:
+          name: apps-bundle.zip
+
+      - name: Download loading-screen.zip
+        uses: actions/download-artifact@v3
+        with:
+          name: loading-screen.zip
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          # If tag_name is empty, action-gh-release falls back to github.ref.
+          tag_name: ${{ inputs.tagname }}
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: |
+            ${{ needs.build.outputs.whl-filename }}
+            ${{ needs.build.outputs.tar-filename }}
+            apps-bundle.zip
+            loading-screen.zip
+
+      - name: Move PyPI artifacts to dist directory
+        run: |
+          mkdir -p dist
+          mv "${{ needs.build.outputs.whl-filename }}" dist
+          mv "${{ needs.build.outputs.tar-filename }}" dist
+
+      - name: Release to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+  trigger_endless-key-app:
+    name: Trigger endless-key-app release
+    runs-on: ubuntu-latest
+    needs: [release]
+
+    steps:
+      - name: Get tag name as the release version when at a tag
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          echo "VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
+
+      - name: Get tag name as the release version from input
+        if: ${{ !startsWith(github.ref, 'refs/tags/') && startsWith(inputs.tagname, 'v') }}
+        run: |
+          echo "VERSION=${{ inputs.tagname }}" >> $GITHUB_ENV
+
+      - name: Trigger building endless-key-app
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.REPOSITORY_DISPATCH_TOKEN }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: "endlessm",
+              repo: "endless-key-app",
+              event_type: "kolibri-explore-plugin-release",
+              client_payload: {
+                VERSION: "${{ env.VERSION }}",
+              }
+            })
+
+  trigger_kolibri-installer-android:
+    name: Trigger kolibri-installer-android release
+    runs-on: ubuntu-latest
+    needs: [release]
+    env:
+      branch: ${{ github.ref }}
+
+    steps:
+      - name: Set branch if this is triggered by bump2release.yml
+        if: startsWith(inputs.tagname, 'v')
+        run: |
+          # The kolibri-explore-plugin release flow from bump2release.yml will
+          # append a new commit to master branch. Therefore, the github.ref is
+          # not at the latest commit. Checkout master instead.
+          echo "branch=${{ inputs.tagname }}" >> $GITHUB_ENV
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.branch }}
+
+      - name: Install trigger_jenkins dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-pip
+          python3 -m pip install requests python-jenkins
+
+      - name: Trigger building kolibri-installer-android
+        run: |
+          ./scripts/trigger_jenkins.py kolibri-installer-android UPLOAD=true
+        env:
+          JENKINS_USER: ${{ secrets.JENKINS_USERNAME }}
+          JENKINS_PASSWORD: ${{ secrets.JENKINS_PASSWORD }}


### PR DESCRIPTION
This adds a few fixes and improvements for the release workflow:

* Restore the ability to have a release created when pushing a tag.
* Make sure a release can only be run from a `v*` tag.
* Don't trigger app builds for major or rc releases since they'll almost certainly fail or be broken.

I ran this several times in my forked repo and am pretty sure it works as expected.

Helps: #815