### PR TITLE
Ek card webkit layout fixes

### DIFF
--- a/packages/ek-components/src/components/EkCardBody.vue
+++ b/packages/ek-components/src/components/EkCardBody.vue
@@ -6,7 +6,7 @@
 
     <!-- Channel -->
     <div v-if="showChannelIcon">
-      <div class="align-items-center d-flex mb-3">
+      <div class="d-flex mb-3">
         <EkChannelLogo class="mr-2" :channel="node.channel" size="sm" />
         <span class="channel-title text-muted text-truncate">{{ node.channel.title }}</span>
       </div>
@@ -15,7 +15,7 @@
     <!-- Title -->
     <div>
       <h5
-        class="align-items-center mb-1 title"
+        class="mb-1 title"
         :class="{ 'text-muted': !node.available }"
       >
         <EkClamp

--- a/packages/ek-components/src/components/EkClamp.vue
+++ b/packages/ek-components/src/components/EkClamp.vue
@@ -25,7 +25,10 @@
     Some width information need to be provided to `<span>s` to allow `text-overflow`
     calculate properly when ellipsis should be added.
   -->
-  <span v-if="text !== ''" :style="{ display: 'inline-block', maxWidth: '100%' }">
+  <span
+    v-if="text !== ''"
+    :style="{ display: 'inline-block', maxWidth: '100%', overflow: 'hidden' }"
+  >
     <span
       v-bind="$attrs"
       :style="{ display: 'inline-block', maxWidth: '100%', ...truncate }"


### PR DESCRIPTION
Two quick fixes for `EkCardBody`, springing from https://github.com/endlessm/kolibri-explore-plugin/issues/810.

Here is a screenshot from the Endless Key app before this change:

![Screenshot from 2023-09-20 17-28-16](https://github.com/endlessm/kolibri-explore-plugin/assets/132063/913f2aae-555b-4e14-af82-364fdabd2174)

… and after this change:

![Screenshot from 2023-09-20 17-28-56](https://github.com/endlessm/kolibri-explore-plugin/assets/132063/5ca54f20-c4b3-4d29-a632-d3f377245124)