### PR TITLE
template-ui: Use v-html to handle <strong> in translation

### DIFF
--- a/packages/template-ui/src/components/ChannelFooter.vue
+++ b/packages/template-ui/src/components/ChannelFooter.vue
@@ -12,9 +12,8 @@
       </template>
       <template #right>
         <div v-if="isEndlessApp" class="endless-seal text-right">
-          <div class="mb-1">
-            {{ $tr('bestOfTheWeb') }}
-          </div>
+          <!-- eslint-disable-next-line vue/no-v-html -->
+          <div class="mb-1" v-html="$tr('bestOfTheWeb')"></div>
           <img :src="logo" aria-hidden="true">
         </div>
       </template>


### PR DESCRIPTION
In vue-intl, `formatMessage` always returns a string, which means any embedded HTML in the translation can't be displayed. Use `v-html` to insert the translation as raw HTML.

Fixes: https://github.com/endlessm/endless-key-flatpak/issues/77