### PR TITLE
Add side nav

### DIFF
--- a/kolibri_explore_plugin/assets/src/components/DiscoveryNavBar.vue
+++ b/kolibri_explore_plugin/assets/src/components/DiscoveryNavBar.vue
@@ -1,7 +1,7 @@
 <template>
 
   <EkNavBar class="discovery-navbar">
-    <img class="logo ml-3 mr-5" :src="logo">
+    <img class="logo ml-3 mr-5" :src="logo" @click="onLogoClick">
     <b-button-group class="mx-auto">
       <b-nav-text
         v-if="showDiscoveryTab"
@@ -155,6 +155,11 @@
       },
       onOnline() {
         this.isOffline = false;
+      },
+      onLogoClick(event) {
+        if (event.ctrlKey) {
+          this.$store.commit('topicsRoot/SET_SHOW_SIDE_NAV', true);
+        }
       },
     },
     $trs: {

--- a/kolibri_explore_plugin/assets/src/modules/topicsRoot/handlers.js
+++ b/kolibri_explore_plugin/assets/src/modules/topicsRoot/handlers.js
@@ -329,3 +329,7 @@ function setSearchResults(store, searchResults, kind) {
     store.commit('CORE_SET_PAGE_LOADING', false);
   });
 }
+
+export function setShowSideNav(store, showSideNav) {
+  store.commit('topicsRoot/SET_SHOW_SIDE_NAV', showSideNav);
+}

--- a/kolibri_explore_plugin/assets/src/modules/topicsRoot/index.js
+++ b/kolibri_explore_plugin/assets/src/modules/topicsRoot/index.js
@@ -5,6 +5,7 @@ export default {
     searchResult: {},
     carouselNodes: [],
     lastSearchPromises: {},
+    showSideNav: false,
   },
   mutations: {
     SET_STATE(state, payload) {
@@ -24,6 +25,9 @@ export default {
     },
     RESET_LAST_SEARCH_PROMISES(state) {
       state.lastSearchPromises = {};
+    },
+    SET_SHOW_SIDE_NAV(state, showSideNav) {
+      state.showSideNav = showSideNav;
     },
   },
 };

--- a/kolibri_explore_plugin/assets/src/views/ExploreIndex.vue
+++ b/kolibri_explore_plugin/assets/src/views/ExploreIndex.vue
@@ -21,6 +21,7 @@
     </b-overlay>
     <router-view />
     <SideNav
+      v-if="enableSideNav"
       ref="sideNav"
       class="side-nav"
       :navShown="showSideNav"
@@ -39,6 +40,7 @@
   import LoadingImage from 'ek-components/src/assets/loading-animation.gif';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import SideNav from 'kolibri.coreVue.components.SideNav';
+  import plugin_data from 'plugin_data';
   import { PageNames } from '../constants';
   import AboutModal from '../components/AboutModal';
   import commonExploreStrings from './commonExploreStrings';
@@ -96,6 +98,9 @@
       },
       loadingImg() {
         return LoadingImage;
+      },
+      enableSideNav() {
+        return plugin_data.enableSideNav;
       },
     },
     watch: {

--- a/kolibri_explore_plugin/assets/src/views/ExploreIndex.vue
+++ b/kolibri_explore_plugin/assets/src/views/ExploreIndex.vue
@@ -20,6 +20,13 @@
       </template>
     </b-overlay>
     <router-view />
+    <SideNav
+      ref="sideNav"
+      class="side-nav"
+      :navShown="showSideNav"
+      @toggleSideNav="toggleSideNav()"
+      @shouldFocusFirstEl="findFirstEl()"
+    />
   </div>
 
 </template>
@@ -31,6 +38,7 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import LoadingImage from 'ek-components/src/assets/loading-animation.gif';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import SideNav from 'kolibri.coreVue.components.SideNav';
   import { PageNames } from '../constants';
   import AboutModal from '../components/AboutModal';
   import commonExploreStrings from './commonExploreStrings';
@@ -65,6 +73,7 @@
       AboutModal,
       ContentModal,
       DevTag,
+      SideNav,
     },
     mixins: [commonCoreStrings, commonExploreStrings, responsiveWindowMixin],
     data() {
@@ -75,6 +84,7 @@
     },
     computed: {
       ...mapState(['pageName']),
+      ...mapState('topicsRoot', { showSideNav: 'showSideNav' }),
       currentPage() {
         return pageNameToComponentMap[this.pageName] || null;
       },
@@ -112,6 +122,14 @@
       },
       onCustomPresentationLoadCompleted() {
         this.isCustomPresentationLoading = false;
+      },
+      toggleSideNav() {
+        this.$store.commit('topicsRoot/SET_SHOW_SIDE_NAV', !this.showSideNav);
+      },
+      findFirstEl() {
+        this.$nextTick(() => {
+          this.$refs.sideNav.focusFirstEl();
+        });
       },
     },
   };
@@ -154,6 +172,19 @@
   // https://stackoverflow.com/questions/32862394/bootstrap-modals-keep-adding-padding-right-to-body-after-closed
   body.modal-open {
     padding-right: 0 !important;
+  }
+
+</style>
+
+
+<style lang="scss" scoped>
+
+  ::v-deep .side-nav .bottom-bar {
+    display: none !important;
+  }
+
+  ::v-deep .side-nav .modal {
+    display: initial;
   }
 
 </style>

--- a/kolibri_explore_plugin/kolibri_plugin.py
+++ b/kolibri_explore_plugin/kolibri_plugin.py
@@ -60,6 +60,7 @@ class ExploreAsset(webpack_hooks.WebpackBundleHook):
                 "SHOW_AS_STANDALONE_CHANNEL"
             ],
             "useEkIguanaPage": conf.OPTIONS["Explore"]["USE_EK_IGUANA_PAGE"],
+            "enableSideNav": conf.OPTIONS["Explore"]["ENABLE_SIDE_NAV"],
             "hideDiscoveryTab": conf.OPTIONS["Explore"]["HIDE_DISCOVERY_TAB"],
             "feedbackUrl": conf.OPTIONS["Explore"]["FEEDBACK_URL"],
         }

--- a/kolibri_explore_plugin/options.py
+++ b/kolibri_explore_plugin/options.py
@@ -36,6 +36,14 @@ option_spec = {
               tagged accordingly to fill the sections of the landing page.
             """,
         },
+        "ENABLE_SIDE_NAV": {
+            "type": "boolean",
+            "default": False,
+            "description": """
+                Whether to show the Kolibri navigation bar in the Explore
+                page.
+            """,
+        },
         "HIDE_DISCOVERY_TAB": {
             "type": "boolean",
             "default": False,

--- a/packages/ek-components/src/components/EkBackToTop.vue
+++ b/packages/ek-components/src/components/EkBackToTop.vue
@@ -57,7 +57,7 @@
     position: fixed;
     bottom: $spacer;
     right: $spacer;
-    z-index: $zindex-fixed;
+    z-index: 7;
     // Remove 2px border from the actual size to match the slidable cards row:
     width: $circled-button-size + 4px;
     height: $circled-button-size + 4px;

--- a/packages/ek-components/src/components/EkNavBar.vue
+++ b/packages/ek-components/src/components/EkNavBar.vue
@@ -55,6 +55,12 @@
   .navbar {
     height: $navbar-height;
     @include transition($btn-transition);
+
+    &.fixed-top {
+      /* Override excessively high z-index from .fixed-top. A value of 8 is
+       * used for Kolibri's AppBar component. */
+      z-index: 8;
+    }
   }
 
 </style>


### PR DESCRIPTION
This adds Kolibri's `SideNav` component to `ExploreIndex` when the `ENABLE_SIDE_NAV` option is True. When enabled, it can be toggled by clicking the Endless logo while holding the Ctrl key.

Here is an example, running the Endless Key app but after starting kolibri-daemon like this:

```
env KOLIBRI_ENABLE_SIDE_NAV=yes flatpak run --command=/app/libexec/kolibri-app/kolibri-daemon org.endlessos.Key.Devel
```

![image](https://github.com/endlessm/kolibri-explore-plugin/assets/132063/6d1a1b59-b699-45e3-a80e-c610a21e3b80)

I think this is useful for testing the Explore plugin while doing other things with Kolibri (such as managing content or device settings), and my hope is it could replace our "showmedevice" cheat code eventually :)

Note that the SideNav in Kolibri 0.16 unfortunately includes other things which are not the sidebar (specifically a bottom bar thing). So I need to hide those via CSS. But that stuff only pollutes the DOM when we set `ENABLE_SIDE_NAV`.