### PR TITLE
loading-screen: Update es-419 translation with properly translated st…

### DIFF
--- a/packages/loading-screen/lang/es-419.json
+++ b/packages/loading-screen/lang/es-419.json
@@ -1,7 +1,7 @@
 {
   "loadingErrorGuidance": {
     "developer_comment": "Guidance for what to do if loading Endless Key failed",
-    "string": "Intente reiniciar Endless Key cerrando esta ventana y haciendo doble clic en el iniciador nuevamente."
+    "string": "Por favor, intenta reiniciar Endless Key cerrando esta ventana y dando click nuevamente al ícono de inicio del programa."
   },
   "loadingErrorTitle": {
     "developer_comment": "Title heading for when Endless Key could not load due to an error",
@@ -13,11 +13,11 @@
   },
   "loadingTryingAgain": {
     "developer_comment": "Page content shown when trying to load Endless Key again after an error",
-    "string": "Intentando otra vez…"
+    "string": "Intentando de nuevo…"
   },
   "poweredByKolibri": {
     "developer_comment": "Footer text to acknowledge that Endless Key is based on Kolibri",
-    "string": "Desarrollado por Kolibri"
+    "string": "Impulsado por Kolibri"
   },
   "welcomeDocumentTitle": {
     "developer_comment": "Document title for the welcome page",
@@ -25,6 +25,6 @@
   },
   "welcomeTitle": {
     "developer_comment": "Title heading for the welcome page",
-    "string": "Bienvenido a Endless Key!"
+    "string": "¡Bienvenido a Endless Key!"
   }
 }


### PR DESCRIPTION
…rings

This fixes the initial, incorrect, translation I did for testing purposes, using the properly translated strings from https://docs.google.com/spreadsheets/d/1fYO_rili_EVrdMiG3LTZf6AHyqTo2KG_eaIcL7yh__U/edit#gid=644360418.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

Helps: #765