### PR TITLE
Style: Import all font weights

### DIFF
--- a/packages/ek-components/package.json
+++ b/packages/ek-components/package.json
@@ -9,8 +9,8 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "@fontsource/lato": "^4.4.5",
-    "@fontsource/poppins": "^4.4.5",
+    "@fontsource/lato": "^5.0.0",
+    "@fontsource/poppins": "^5.0.0",
     "bootstrap": "^4.6.1",
     "bootstrap-vue": "^2.22.0",
     "core-js": "^3.6.5",

--- a/packages/ek-components/src/index.scss
+++ b/packages/ek-components/src/index.scss
@@ -1,10 +1,27 @@
+@use "@fontsource/lato/scss/mixins" as Lato;
+@use "@fontsource/poppins/scss/mixins" as Poppins;
+
 @import 'styles';
 
 @import 'bootstrap/scss/bootstrap';
 @import 'bootstrap-vue/src/index';
 
-@import "~@fontsource/lato/index.css";
-@import "~@fontsource/poppins/index.css";
+@include Lato.faces(
+  $weights: (
+    400,
+    700,
+  ),
+  $formats: woff2
+);
+
+@include Poppins.faces(
+  $weights: (
+    400,
+    600,
+    700,
+  ),
+  $formats: woff2
+);
 
 // Override containers mixin:
 @mixin make-container($gutter: $grid-gutter-width) {

--- a/packages/loading-screen/package.json
+++ b/packages/loading-screen/package.json
@@ -11,6 +11,8 @@
     "compile-messages": "formatjs compile-folder --format transifex lang compiled-lang"
   },
   "dependencies": {
+    "@fontsource/lato": "^5.0.0",
+    "@fontsource/poppins": "^5.0.0",
     "bootstrap": "^4.6.1",
     "bootstrap-vue": "^2.22.0",
     "vue": "^2.6.11"

--- a/packages/loading-screen/src/index.scss
+++ b/packages/loading-screen/src/index.scss
@@ -1,10 +1,27 @@
+@use "@fontsource/lato/scss/mixins" as Lato;
+@use "@fontsource/poppins/scss/mixins" as Poppins;
+
 @import 'styles';
 
 @import 'bootstrap/scss/bootstrap';
 @import 'bootstrap-vue/src/index';
 
-@import "~@fontsource/lato/index.css";
-@import "~@fontsource/poppins/index.css";
+@include Lato.faces(
+  $weights: (
+    400,
+    700,
+  ),
+  $formats: woff2
+);
+
+@include Poppins.faces(
+  $weights: (
+    400,
+    600,
+    700,
+  ),
+  $formats: woff2
+);
 
 // Override containers mixin:
 @mixin make-container($gutter: $grid-gutter-width) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1984,15 +1984,15 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@fontsource/lato@^4.4.5":
-  version "4.5.5"
-  resolved "https://registry.yarnpkg.com/@fontsource/lato/-/lato-4.5.5.tgz#d7371e29600528a44f5076a1604cf223168d1579"
-  integrity sha512-0KVmVCq3wZnriKVdbY+n/ZLf7Vy+dQcqpcm8kaVX4QGd6uBTgH6YWLnM1L051TtjKlal2FiE6xc/BLw116a0gQ==
+"@fontsource/lato@^5.0.0":
+  version "5.0.12"
+  resolved "https://registry.yarnpkg.com/@fontsource/lato/-/lato-5.0.12.tgz#2290a23aaf3a25dd9aba4022aa131a689cfbd3fa"
+  integrity sha512-49kN7Ty0mDicmxNdaaDuOFtY5hvAwFN1pXkxaJJVlozh4v/houKwvodM3L7QVJEUC4KfNVEwn5Y409Us+EyFWw==
 
-"@fontsource/poppins@^4.4.5":
-  version "4.5.5"
-  resolved "https://registry.yarnpkg.com/@fontsource/poppins/-/poppins-4.5.5.tgz#db08da1c37db30eb06d75c2abdd9c62118dbab8b"
-  integrity sha512-fqRWOQDhfoJoxP98qwMQLvLcgOu13yib6rZjL5UqpurobIaWTweqzo95uOLOGBjEE0bMMAbfDMoFUTL8Byrdeg==
+"@fontsource/poppins@^5.0.0":
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/@fontsource/poppins/-/poppins-5.0.8.tgz#a1c5540aedb3719a36eba5c7c5dfaa3aed3c9f80"
+  integrity sha512-P8owfYWluoUY5Nyzk4gT/L6LmLmseP6ezFWhj6VBUa5pRIdnCvNJpoQ6i/vhekjtJOfqX6nKlB+LCttoUl2GQQ==
 
 "@formatjs/cli@^4.5.0":
   version "4.8.4"


### PR DESCRIPTION
Add a list of all possible weights for each font (Lato, Poppins) and import them.

This should be done with a single import line, but it fails with wrong paths to the font file. So we have to use the SCSS mixin.

Previously only the default font weight (400) was being imported, so text with other weights looked different depending on the web engine used.

Fixes #810