### PR TITLE
Handlers: Fix root URL redirect

### DIFF
--- a/kolibri_explore_plugin/assets/src/modules/topicsRoot/handlers.js
+++ b/kolibri_explore_plugin/assets/src/modules/topicsRoot/handlers.js
@@ -162,10 +162,10 @@ export function decideWelcome(store) {
             store.commit('CORE_SET_PAGE_LOADING', false);
             store.commit('CORE_SET_ERROR', null);
           } else {
-            console.debug('Welcome: Redirecting to Explore page...');
-            router.replace({ name: PageNames.TOPICS_ROOT });
             store.commit('CORE_SET_PAGE_LOADING', false);
             store.commit('CORE_SET_ERROR', null);
+            console.debug('Welcome: Redirecting to Explore page...');
+            router.replace({ name: PageNames.TOPICS_ROOT });
           }
         });
       }


### PR DESCRIPTION
The redirect should happen after the loading state is set. Each handler sets loading to true at the very beginning and to false at the very end. But because of the redirect, the TOPICS handler (showChannels) was starting in the middle of the ROOT handler (decideWelcome). Thus the state was mixed up and not to be trusted.

Fixes #799