### PR TITLE
Feedback form: Use different URL for Spanish

### DIFF
--- a/kolibri_explore_plugin/assets/src/components/DiscoveryNavBar.vue
+++ b/kolibri_explore_plugin/assets/src/components/DiscoveryNavBar.vue
@@ -65,6 +65,7 @@
 
 <script>
 
+  import { currentLanguage, languageIdToCode } from 'kolibri.utils.i18n';
   import ViewDashboardOutlineIcon from 'vue-material-design-icons/ViewDashboardOutline.vue';
   import MagnifyIcon from 'vue-material-design-icons/Magnify.vue';
   import MessageReplyTextOutlineIcon from 'vue-material-design-icons/MessageReplyTextOutline.vue';
@@ -96,7 +97,12 @@
         return assets.EndlessLogo;
       },
       feedbackUrl() {
-        return plugin_data.feedbackUrl;
+        switch (languageIdToCode(currentLanguage)) {
+          case 'es':
+            return plugin_data.feedbackUrlEs;
+          default:
+            return plugin_data.feedbackUrl;
+        }
       },
       showFeedbackButton() {
         return plugin_data.feedbackUrl != '';

--- a/kolibri_explore_plugin/kolibri_plugin.py
+++ b/kolibri_explore_plugin/kolibri_plugin.py
@@ -63,6 +63,7 @@ class ExploreAsset(webpack_hooks.WebpackBundleHook):
             "enableSideNav": conf.OPTIONS["Explore"]["ENABLE_SIDE_NAV"],
             "hideDiscoveryTab": conf.OPTIONS["Explore"]["HIDE_DISCOVERY_TAB"],
             "feedbackUrl": conf.OPTIONS["Explore"]["FEEDBACK_URL"],
+            "feedbackUrlEs": conf.OPTIONS["Explore"]["FEEDBACK_URL_ES"],
         }
         if "Pwa" in conf.OPTIONS:
             pwa_options = {

--- a/kolibri_explore_plugin/options.py
+++ b/kolibri_explore_plugin/options.py
@@ -59,5 +59,12 @@ option_spec = {
                 to hide it
             """,
         },
+        "FEEDBACK_URL_ES": {
+            "type": "string",
+            "default": "https://endlessos.org/key-feedback-es",
+            "description": """
+                Form to link to from the Feedback button for Spanish.
+            """,
+        },
     },
 }


### PR DESCRIPTION
As the original feedback URL, it can be overriden with a setting. Useful for changing the ES feeback URL in the online instance.

Unfortunately the plugin option can't be generalized to other languages because the INI file should be kept simple (ie no mapping data type).

Fixes #858