### PR TITLE
Routing: Fix one more page mounting early

### DIFF
--- a/kolibri_explore_plugin/assets/src/modules/topicsRoot/handlers.js
+++ b/kolibri_explore_plugin/assets/src/modules/topicsRoot/handlers.js
@@ -215,9 +215,9 @@ export function decideDownload(store, grade, name) {
             });
           } else {
             console.debug('Conditions not met to download, assuming as completed.');
-            router.replace({ name: PageNames.TOPICS_ROOT });
             store.commit('CORE_SET_PAGE_LOADING', false);
             store.commit('CORE_SET_ERROR', null);
+            router.replace({ name: PageNames.TOPICS_ROOT });
           }
         });
       }


### PR DESCRIPTION
Like in 4deba013. In this case the Topics (home) page could be mounted early when redirected from the Download page. Because the redirect was happening after setting "loading" and "error" to false.

Fixes #799