### PR TITLE
Theme: Change secondary color

### DIFF
--- a/kolibri_explore_plugin/assets/src/components/DiscoveryNavBar.vue
+++ b/kolibri_explore_plugin/assets/src/components/DiscoveryNavBar.vue
@@ -191,7 +191,7 @@
 
   .discovery-tab {
     &.active {
-      border-bottom: 2px solid $secondary;
+      border-bottom: 2px solid $endless-orange;
     }
   }
 

--- a/packages/ek-components/src/components/EkTopicCard.vue
+++ b/packages/ek-components/src/components/EkTopicCard.vue
@@ -8,7 +8,7 @@
     }"
   >
     <EkContentLink :url="url" @isHovered="(hovered) => isHovered = hovered">
-      <b-card-body class="bg-primary">
+      <b-card-body class="bg-secondary">
         <div
           class="card-img"
           :class="{ 'low-quality': isLowQuality, 'is-thumbnail-wide': isThumbnailWide }"
@@ -39,7 +39,7 @@
               <span class="channel-title subtitle text-truncate">{{ node.channel.title }}</span>
             </div>
             <div v-else>
-              <b-badge pill variant="primary">
+              <b-badge pill variant="secondary">
                 <BundleIcon :size="20" />
                 {{ $tr('exploreBadge') }}
               </b-badge>

--- a/packages/ek-components/src/styles.scss
+++ b/packages/ek-components/src/styles.scss
@@ -1,5 +1,5 @@
 // Bootstrap theme variables:
-$secondary: #F15A22;
+$secondary: #064987;
 $gray-300: #F8F7F3;
 $gray-400: #ECE8E3;
 $gray-500: #A1A8A9;
@@ -11,6 +11,7 @@ $primary: $gray-800;
 $light: $gray-300;
 $dark: $gray-600;
 
+$endless-orange: #F15A22;
 $orange: #FF9741;
 $yellow: #F5BD2C;
 $teal: #14BF96;


### PR DESCRIPTION
To make topic cards dark blue.

Use a blue as secondary color and use it in topic cards (previously primary black). Keep the previous secondary color as a custom named color "endless-orange". Use the endless orange in the bottom border of tabs in navbar (discover/library).

Helps #725