### PR TITLE
Download page: Make progress bar orange again

### DIFF
--- a/kolibri_explore_plugin/assets/src/views/DownloadPage.vue
+++ b/kolibri_explore_plugin/assets/src/views/DownloadPage.vue
@@ -23,7 +23,7 @@
             <b-progress
               :max="1"
               :value="displayProgress"
-              variant="secondary"
+              variant="endless-orange"
               animated
             />
             <p class="mt-1">


### PR DESCRIPTION
This has regressed in the theme changes.

Helps #725