### PR TITLE
Skip downloading when all content available

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,7 @@ tomli = "*"
 pytest = "~=7.4"
 pytest-django = "~=3.10"
 pytest-rerunfailures = "~=12.0"
+requests-mock = "~=1.11"
 
 [packages]
 nodeenv = "==1.3.3"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2fb4237dd4fb8a8f758ee395f171910347678442d57cc68b1b502aeeec09d8d1"
+            "sha256": "b9e6c6eef3b66e97de0663c14f43afed1285532f109cf9bd4ec505958d801fe7"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -844,6 +844,14 @@
             "markers": "python_version >= '3.7'",
             "version": "==2.31.0"
         },
+        "requests-mock": {
+            "hashes": [
+                "sha256:ef10b572b489a5f28e09b708697208c4a3b2b89ef80a9f01584340ea357ec3c4",
+                "sha256:f7fae383f228633f6bececebdab236c478ace2284d6292c6e7e2867b9ab74d15"
+            ],
+            "index": "pypi",
+            "version": "==1.11.0"
+        },
         "requests-toolbelt": {
             "hashes": [
                 "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6",
@@ -894,6 +902,14 @@
             ],
             "index": "pypi",
             "version": "==8.0.4"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.16.0"
         },
         "toml": {
             "hashes": [

--- a/kolibri_explore_plugin/test/test_jobs.py
+++ b/kolibri_explore_plugin/test/test_jobs.py
@@ -1,6 +1,5 @@
 import pytest
 from django.core.management import call_command
-from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.tasks.job import State
 
 from .utils import wait_for_background_tasks
@@ -70,7 +69,7 @@ def test_get_remotecontentimport_task():
     ]
 
     # If the channel doesn't exist an exception will be raised.
-    with pytest.raises(ChannelMetadata.DoesNotExist):
+    with pytest.raises(ValueError, match=r"does not exist"):
         jobs.get_remotecontentimport_task(channel_id)
 
     # Import the channel and try again with no nodes specified.


### PR DESCRIPTION
This allows completing the downloader offline when all content is available by skipping unnecessary channel imports. Otherwise, Kolibri will always tries to import channels in case the remote version has been updated. We don't need that since the desired channel version is specified in the starter pack.

This is on top of #897, which allowed me to confirm it would work and catch a couple bugs I would have otherwise missed.

Fixes: #890