### PR TITLE
Skip content import

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,6 @@
 [flake8]
 extend-exclude =
+  kolibri_explore_plugin/_version.py,
   build/,
   static/,
   dist/,

--- a/kolibri_explore_plugin/collectionviews.py
+++ b/kolibri_explore_plugin/collectionviews.py
@@ -12,6 +12,9 @@ from kolibri.core.content.utils.content_manifest import ContentManifest
 from kolibri.core.content.utils.content_manifest import (
     ContentManifestParseError,
 )
+from kolibri.core.content.utils.import_export_content import (
+    get_import_export_data,
+)
 from kolibri.core.tasks.job import State as JobState
 from kolibri.core.tasks.main import job_storage
 from kolibri.utils import conf
@@ -189,6 +192,20 @@ class EndlessKeyContentManifest(ContentManifest):
             node_ids = list(
                 self._get_node_ids_for_channel(channel_metadata, channel_id)
             )
+
+            # Check if the desired nodes are already available.
+            num_resources, _, _ = get_import_export_data(
+                channel_id,
+                node_ids=node_ids,
+                available=False,
+            )
+            if num_resources == 0:
+                logger.debug(
+                    f"Skipping content import task for {channel_id} "
+                    "since all resources already present"
+                )
+                continue
+
             tasks.append(
                 get_remotecontentimport_task(
                     channel_id, channel_metadata.name, node_ids
@@ -219,12 +236,30 @@ class EndlessKeyContentManifest(ContentManifest):
 
         For all the channels in this content manifest.
         """
-        return [
-            get_remotecontentimport_task(
-                channel_id, node_ids=[], all_thumbnails=True
+        tasks = []
+
+        for channel_id in self.get_channel_ids():
+            # Check if the desired thumbnail nodes are already available.
+            num_resources, _, _ = get_import_export_data(
+                channel_id,
+                node_ids=[],
+                available=False,
+                all_thumbnails=True,
             )
-            for channel_id in self.get_channel_ids()
-        ]
+            if num_resources == 0:
+                logger.debug(
+                    f"Skipping content thumbnail task for {channel_id} "
+                    "since all resources already present"
+                )
+                continue
+
+            tasks.append(
+                get_remotecontentimport_task(
+                    channel_id, node_ids=[], all_thumbnails=True
+                )
+            )
+
+        return tasks
 
     def _get_node_ids_for_channel(self, channel_metadata, channel_id):
         """Get node IDs regardless of the version

--- a/kolibri_explore_plugin/test/conftest.py
+++ b/kolibri_explore_plugin/test/conftest.py
@@ -77,27 +77,12 @@ def contentdir(serverdir):
 @pytest.fixture
 def content_server(serverdir, contentdir, monkeypatch):
     """HTTP content server using test data"""
-    from kolibri.core.discovery.utils.network.client import NetworkClient
-    from kolibri.core.content.utils import resource_import
-
     with ContentServer(serverdir) as server:
         # Override the Kolibri content server URL.
         monkeypatch.setitem(
             OPTIONS["Urls"],
             "CENTRAL_CONTENT_BASE_URL",
             server.url,
-        )
-
-        # Don't introspect the server for info.
-        monkeypatch.setattr(
-            NetworkClient,
-            "build_for_address",
-            lambda addr: NetworkClient(addr),
-        )
-        monkeypatch.setattr(
-            resource_import,
-            "lookup_channel_listing_status",
-            lambda channel_id, baseurl: None,
         )
 
         yield server

--- a/kolibri_explore_plugin/test/test_collectionviews.py
+++ b/kolibri_explore_plugin/test/test_collectionviews.py
@@ -9,12 +9,14 @@ from django.urls import reverse
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.models import ContentNode
 from kolibri.core.content.models import LocalFile
+from kolibri.core.tasks import main as tasks_main
 from rest_framework.test import APIClient
 
 from .utils import COLLECTIONSDIR
 from .utils import ExploreTestTimeoutError
 from .utils import wait_for_background_tasks
 from kolibri_explore_plugin import collectionviews
+from kolibri_explore_plugin.jobs import TaskType
 
 
 @pytest.mark.django_db
@@ -220,6 +222,11 @@ def test_download_manager_preload(facility_user, grade, name):
     assert num_initial_channels == len(all_channels)
     assert LocalFile.objects.filter(available=False).count() == 0
 
+    # Clear all the jobs to check if any downloading jobs were created
+    # later.
+    job_storage = tasks_main.job_storage
+    job_storage.clear(force=True)
+
     # Run the downloader with requests blocked. Since no URLs are mocked, all
     # requests will fail. Since the download manager retries tasks forever, it
     # will eventually time out on any request.
@@ -233,3 +240,9 @@ def test_download_manager_preload(facility_user, grade, name):
     assert (
         LocalFile.objects.filter(available=True).count() == num_initial_files
     )
+
+    # Check that no channel or content import jobs were created.
+    channel_jobs = job_storage.filter_jobs(func=TaskType.REMOTECHANNELIMPORT)
+    assert channel_jobs == []
+    content_jobs = job_storage.filter_jobs(func=TaskType.REMOTECONTENTIMPORT)
+    assert content_jobs == []

--- a/kolibri_explore_plugin/test/test_collectionviews.py
+++ b/kolibri_explore_plugin/test/test_collectionviews.py
@@ -246,3 +246,5 @@ def test_download_manager_preload(facility_user, grade, name):
     assert channel_jobs == []
     content_jobs = job_storage.filter_jobs(func=TaskType.REMOTECONTENTIMPORT)
     assert content_jobs == []
+    import_jobs = job_storage.filter_jobs(func=TaskType.REMOTEIMPORT)
+    assert import_jobs == []

--- a/kolibri_explore_plugin/test/utils.py
+++ b/kolibri_explore_plugin/test/utils.py
@@ -54,7 +54,7 @@ def create_contentdir(content_path, channels_path=CHANNELSDIR):
     storage_path.mkdir(parents=True, exist_ok=True)
 
     for json_path in iglob(f"{channels_path}/*.json"):
-        logger.info(f"Loading channel JSON {json_path}")
+        logger.debug(f"Loading channel JSON {json_path}")
         with open(json_path, "r") as f:
             data = json.load(f)
 
@@ -67,16 +67,16 @@ def create_contentdir(content_path, channels_path=CHANNELSDIR):
         channel_id = channels[0]["id"]
         db_path = databases_path / f"{channel_id}.sqlite3"
         if db_path.exists():
-            logger.info(f"Removing existing channel database {db_path}")
+            logger.debug(f"Removing existing channel database {db_path}")
             db_path.unlink()
 
-        logger.info(f"Creating channel database {db_path}")
+        logger.debug(f"Creating channel database {db_path}")
         bridge = Bridge(db_path, schema_version=CURRENT_SCHEMA_VERSION)
         bridge.Base.metadata.bind = bridge.engine
         bridge.Base.metadata.create_all()
 
         # Create the content files from the localfile _content entries.
-        logger.info(f"Creating channel {channel_id} content files")
+        logger.debug(f"Creating channel {channel_id} content files")
         for localfile in data["content_localfile"]:
             id = localfile["id"]
             size = localfile["file_size"]
@@ -101,7 +101,7 @@ def create_contentdir(content_path, channels_path=CHANNELSDIR):
             localfile_dir.mkdir(parents=True, exist_ok=True)
             localfile_path = localfile_dir / f"{id}.{ext}"
             if localfile_path.exists():
-                logger.info(f"Validating content file {localfile_path}")
+                logger.debug(f"Validating content file {localfile_path}")
                 localfile_size = os.path.getsize(localfile_path)
                 if localfile_size != size:
                     raise ValueError(

--- a/kolibri_explore_plugin/test/utils.py
+++ b/kolibri_explore_plugin/test/utils.py
@@ -8,6 +8,7 @@ import logging
 import multiprocessing
 import os
 import queue
+import shutil
 import threading
 import time
 from base64 import b64decode
@@ -65,6 +66,13 @@ def create_contentdir(content_path, channels_path=CHANNELSDIR):
             )
 
         channel_id = channels[0]["id"]
+
+        # For convenience, copy the input JSON file so the data can be
+        # introspected without loading a sqlite database.
+        db_json_path = databases_path / f"{channel_id}.json"
+        logger.debug(f"Creating channel JSON data {db_json_path}")
+        shutil.copyfile(json_path, db_json_path)
+
         db_path = databases_path / f"{channel_id}.sqlite3"
         if db_path.exists():
             logger.debug(f"Removing existing channel database {db_path}")


### PR DESCRIPTION
Like was done with channel imports, skip content import tasks if all the resources are already available. This is needed when the device is online because Kolibri will probe the channel data from the server regardless of whether content is needed or not. While working on this, I noticed that extra channel thumbnail downloads may be skipped if the channel was already present.

Sorry this is a bit big. I wanted to be sure there really wouldn't be any network requests if they weren't needed. That involved a bit of work with the test studio server so that it could respond to all the requests without having them stubbed out.

Fixes: #890